### PR TITLE
Improve the item based encumbrance UI.

### DIFF
--- a/src/module/actor/data-model-classes/data-model-character-encumbrance-item-based.ts
+++ b/src/module/actor/data-model-classes/data-model-character-encumbrance-item-based.ts
@@ -155,6 +155,35 @@ export default class OseDataModelCharacterEncumbranceItemBased
         );
   }
 
+  get equippedSteps() {
+    return Object.values(
+          OseDataModelCharacterEncumbranceItemBased.equippedEncumbranceSteps
+        );
+  }
+
+  get packedSteps() {
+    return Object.values(
+          OseDataModelCharacterEncumbranceItemBased.packedEncumbranceSteps
+        );
+  }
+
+  get equippedPct() {
+    return Math.clamp((100 * this.#equippedWeight) / this.#equippedMax, 0, 100);
+  }
+
+  get packedPct() {
+    return Math.clamp((100 * (this.#packedWeight - this.#weightMod)) / this.#packedMax, 0, 100);
+  }
+
+  get equippedLabel() : string {
+    return this.#equippedWeight + "/" + this.#equippedMax;
+  }
+
+  get packedLabel() : string {
+    return this.#packedWeight + "/" + (this.#packedMax + this.#weightMod)
+  }
+
+
   get usingEquippedEncumbrance() {
     const equippedValues = Object.values(
       OseDataModelCharacterEncumbranceItemBased.equippedEncumbranceSteps

--- a/src/templates/actors/partials/character-inventory-tab.html
+++ b/src/templates/actors/partials/character-inventory-tab.html
@@ -407,21 +407,45 @@
 </section>
 {{#unless (eq @root.system.encumbrance.variant 'disabled')}}
 <section>
-  
-  {{#with @root.system.encumbrance}}
-  <div class="encumbrance {{#if encumbered}}encumbered{{/if}}">
 
-    <span class="encumbrance-bar" style="width:{{pct}}%"></span>
-    {{#if @root.config.encumbranceStrengthMod}}
-    <span class="encumbrance-label">{{value}} / {{#if usingEquippedEncumbrance}}{{max}}{{else}}{{add max @root.system.scores.str.mod}}{{/if}}</span>
-    {{else}}
-    <span class="encumbrance-label">{{value}} / {{max}}</span>
-    {{/if}}
-    {{#each steps as |s|}}
-    <i class="encumbrance-breakpoint arrow-up" style="left:{{s}}%"></i>
-    <i class="encumbrance-breakpoint arrow-down" style="left:{{s}}%"></i>
-    {{/each}}
-  </div>
+  {{#with @root.system.encumbrance}}
+  {{#if (eq @root.config.encumbrance "itembased")}}
+    <!-- Equipped bar -->
+    <div class="encumbrance {{#if encumbered}}encumbered{{/if}}">
+
+      <span class="encumbrance-bar" style="width:{{equippedPct}}%"></span>
+      <span class="encumbrance-label">Equipped {{equippedLabel}}</span>
+      {{#each equippedSteps as |s|}}
+      <i class="encumbrance-breakpoint arrow-up" style="left:{{s}}%"></i>
+      <i class="encumbrance-breakpoint arrow-down" style="left:{{s}}%"></i>
+      {{/each}}
+    </div>
+
+    <!-- Packed bar-->
+    <div class="encumbrance {{#if encumbered}}encumbered{{/if}}">
+
+      <span class="encumbrance-bar" style="width:{{packedPct}}%"></span>
+      <span class="encumbrance-label">Packed {{packedLabel}}</span>
+      {{#each packedSteps as |s|}}
+      <i class="encumbrance-breakpoint arrow-up" style="left:{{s}}%"></i>
+      <i class="encumbrance-breakpoint arrow-down" style="left:{{s}}%"></i>
+      {{/each}}
+    </div>
+  {{else}}
+    <div class="encumbrance {{#if encumbered}}encumbered{{/if}}">
+
+      <span class="encumbrance-bar" style="width:{{pct}}%"></span>
+      {{#if @root.config.encumbranceStrengthMod}}
+      <span class="encumbrance-label">{{value}} / {{#if usingEquippedEncumbrance}}{{max}}{{else}}{{add max @root.system.scores.str.mod}}{{/if}}</span>
+      {{else}}
+      <span class="encumbrance-label">{{value}} / {{max}}</span>
+      {{/if}}
+      {{#each steps as |s|}}
+      <i class="encumbrance-breakpoint arrow-up" style="left:{{s}}%"></i>
+      <i class="encumbrance-breakpoint arrow-down" style="left:{{s}}%"></i>
+      {{/each}}
+    </div>
+  {{/if}}  
   {{/with}}
 </section>
 {{/unless}}


### PR DESCRIPTION
A single bar is not very useful for item based encumbrance, because the players can't see how many more items they can carry easily. For example, a PC can have 5 items equipped, but very few packed. How would they know how much treasure they can pick up? Only once they breach the packed limits they will see. Having two bars makes it clearer.

Unfortunately, the data model doesn't support have two bars well, so I made custom methods - they template is dynamic, so it doesn't care about the interface. But, we can consider having a second track in the interface.

Also, I bundle a fix for the percentage in the bar, which wasn't calculated correctly when strenght mod is used. The percentage would be calculated statically.