### PR TITLE
Add expected strings for CONFIG.Item.typeLabels to fix Item Piles and more

### DIFF
--- a/src/lang/ca.json
+++ b/src/lang/ca.json
@@ -287,5 +287,12 @@
   "OSE.error.notEnoughGP": "Aquest actor no té prou peces d'or per pagar el seu inventari.",
   "OSE.error.itemNoLongerExistsOnActor": "L'objecte {itemId} solicitat ja no existeix en l'actor {actorName}.",
   "OSE.error.noTokenControlled": "Cal controlar un o més avatars per poder fer servir aquesta opció.",
-  "OSE.error.noGP": "Necessites peces d'or per fer servir aquesta característica."
+  "OSE.error.noGP": "Necessites peces d'or per fer servir aquesta característica.",
+  "TYPES.Base": "Base",
+  "TYPES.Item.ability": "Habilitat",
+  "TYPES.Item.armor": "Armadura",
+  "TYPES.Item.container": "Contenidor",
+  "TYPES.Item.item": "Objecte",
+  "TYPES.Item.spell": "Encantament",
+  "TYPES.Item.weapon": "Arma"
 }

--- a/src/lang/de.json
+++ b/src/lang/de.json
@@ -303,5 +303,12 @@
   "OSE.error.noTokenControlled": "Sie müssen über ein oder mehrere kontrollierte Token verfügen, um diese Option nutzen zu können.",
   "OSE.error.noGP": "Sie benötigen einen GM-Artikel, um diese Funktion zu nutzen.",
   "OSE.error.unexpectedSettings": "unerwartete OSE-Einstellung {configName}: {configValue}",
-  "OSE.error.cantDealDamageTo": "Kann {nameOrId} keinen Schaden zufügen"
+  "OSE.error.cantDealDamageTo": "Kann {nameOrId} keinen Schaden zufügen",
+  "TYPES.Base": "Basis",
+  "TYPES.Item.ability": "Fähigkeit",
+  "TYPES.Item.armor": "Rüstung",
+  "TYPES.Item.container": "Behälter",
+  "TYPES.Item.item": "Gegenstand",
+  "TYPES.Item.spell": "Zauber",
+  "TYPES.Item.weapon": "Waffe"
 }

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -344,6 +344,7 @@
   "TYPES.Item.ability": "Ability",
   "TYPES.Item.armor": "Armor",
   "TYPES.Item.container": "Container",
+  "TYPES.Item.item": "Item",
   "TYPES.Item.spell": "Spell",
   "TYPES.Item.weapon": "Weapon"
 }

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -338,5 +338,12 @@
   "OSE.error.noTokenControlled": "You must have one or more controlled Tokens in order to use this option.",
   "OSE.error.noGP": "You need a GP item to use this feature.",
   "OSE.error.unexpectedSettings": "unexpected OSE setting {configName}: {configValue}",
-  "OSE.error.cantDealDamageTo": "Can't deal damage to {nameOrId}"
+  "OSE.error.cantDealDamageTo": "Can't deal damage to {nameOrId}",
+
+  "TYPES.Base": "Base",
+  "TYPES.Item.ability": "Ability",
+  "TYPES.Item.armor": "Armor",
+  "TYPES.Item.container": "Container",
+  "TYPES.Item.spell": "Spell",
+  "TYPES.Item.weapon": "Weapon"
 }

--- a/src/lang/es.json
+++ b/src/lang/es.json
@@ -307,5 +307,12 @@
   "OSE.error.noTokenControlled": "Debes controlar uno o más tokens para poder utilizar esta opción.",
   "OSE.error.noGP": "Necesitas un objeto MO para poder utilizar esta función.",
   "OSE.error.unexpectedSettings": "configuración de {configName} para OSE incorrecto: {configValue}",
-  "OSE.error.cantDealDamageTo": "No se puede infligir daño a {nameOrId}"
+  "OSE.error.cantDealDamageTo": "No se puede infligir daño a {nameOrId}",
+  "TYPES.Base": "Base",
+  "TYPES.Item.ability": "Habilidad",
+  "TYPES.Item.armor": "Armadura",
+  "TYPES.Item.container": "Contenedor",
+  "TYPES.Item.item": "Objeto",
+  "TYPES.Item.spell": "Hechizo",
+  "TYPES.Item.weapon": "Arma"
 }

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -292,5 +292,13 @@
   "OSE.reaction.Unfriendly": "{name} est Inamical",
   "OSE.reaction.Neutral": "{name} est Neutre",
   "OSE.reaction.Indifferent": "{name} est Indifférent",
-  "OSE.reaction.Friendly": "{name} est Amical"
+  "OSE.reaction.Friendly": "{name} est Amical",
+
+  "TYPES.Base": "Base",
+  "TYPES.Item.ability": "Aptitude",
+  "TYPES.Item.armor": "Armure",
+  "TYPES.Item.container": "Conteneur",
+  "TYPES.Item.item": "Objet",
+  "TYPES.Item.spell": "Sort",
+  "TYPES.Item.weapon": "Arme"
 }

--- a/src/lang/it.json
+++ b/src/lang/it.json
@@ -303,5 +303,12 @@
   "OSE.error.noTokenControlled": "Per poter utilizzare questa opzione, devi controllare almeno un Token.",
   "OSE.error.noGP": "Devi possedere un oggetto \"MO\" per poter utilizzare questa funzione.",
   "OSE.error.unexpectedSettings": "impostazione OSE non prevista {configName}: {configValue}",
-  "OSE.error.cantDealDamageTo": "Impossibile infliggere il danno a {nameOrId}"
+  "OSE.error.cantDealDamageTo": "Impossibile infliggere il danno a {nameOrId}",
+  "TYPES.Base": "Base",
+  "TYPES.Item.ability": "Abilità",
+  "TYPES.Item.armor": "Armatura",
+  "TYPES.Item.container": "Contenitore",
+  "TYPES.Item.item": "Oggetto",
+  "TYPES.Item.spell": "Incantesimo",
+  "TYPES.Item.weapon": "Arma"
 }

--- a/src/lang/ko.json
+++ b/src/lang/ko.json
@@ -299,5 +299,12 @@
   "OSE.error.noTokenControlled": "이 옵션을 사용하려면 하나 이상의 제어 토큰이 있어야 합니다.",
   "OSE.error.noGP": "이 기능을 사용하려면 GP가 필요합니다.",
   "OSE.error.unexpectedSettings": "예기치 않은 OSE 설정 {configName}: {configValue}",
-  "OSE.error.cantDealDamageTo": "{nameOrId}에게 피해를 입힐 수 없습니다"
+  "OSE.error.cantDealDamageTo": "{nameOrId}에게 피해를 입힐 수 없습니다",
+  "TYPES.Base": "기본",
+  "TYPES.Item.ability": "능력",
+  "TYPES.Item.armor": "방어구",
+  "TYPES.Item.container": "컨테이너",
+  "TYPES.Item.item": "아이템",
+  "TYPES.Item.spell": "주문",
+  "TYPES.Item.weapon": "무기"
 }

--- a/src/lang/pl.json
+++ b/src/lang/pl.json
@@ -299,5 +299,12 @@
   "OSE.error.noTokenControlled": "Musisz mieć jedną lub więcej kontrolowanych postaci, aby użyć tej opcji.",
   "OSE.error.noGP": "Potrzebujesz SZ, aby tego użyć.",
   "OSE.error.unexpectedSettings": "nieoczekiwane ustawienie OSE {configName}: {configValue}",
-  "OSE.error.cantDealDamageTo": "Nie można zadać obrażeń dla {nameOrId}"
+  "OSE.error.cantDealDamageTo": "Nie można zadać obrażeń dla {nameOrId}",
+  "TYPES.Base": "Baza",
+  "TYPES.Item.ability": "Umiejętność",
+  "TYPES.Item.armor": "Zbroja",
+  "TYPES.Item.container": "Pojemnik",
+  "TYPES.Item.item": "Przedmiot",
+  "TYPES.Item.spell": "Zaklęcie",
+  "TYPES.Item.weapon": "Broń"
 }

--- a/src/lang/pt-BR.json
+++ b/src/lang/pt-BR.json
@@ -299,5 +299,12 @@
   "OSE.error.noTokenControlled": "Você deve ter um ou mais Tokens controlados para poder usar esta opção.",
   "OSE.error.noGP": "Você precisa do item PO para usar este recurso.",
   "OSE.error.unexpectedSettings": "configuração OSE inesperada {configName}{configValue}",
-  "OSE.error.cantDealDamageTo": "Não é possível causar dano em {nameOrId}"
+  "OSE.error.cantDealDamageTo": "Não é possível causar dano em {nameOrId}",
+  "TYPES.Base": "Base",
+  "TYPES.Item.ability": "Habilidade",
+  "TYPES.Item.armor": "Armadura",
+  "TYPES.Item.container": "Contêiner",
+  "TYPES.Item.item": "Item",
+  "TYPES.Item.spell": "Magia",
+  "TYPES.Item.weapon": "Arma"
 }

--- a/src/lang/ru.json
+++ b/src/lang/ru.json
@@ -299,5 +299,12 @@
   "OSE.error.noTokenControlled": "Для использования этой опции необходимо иметь один или несколько контролируемых токенов.",
   "OSE.error.noGP": "Для использования этой функции необходим GP предмет.",
   "OSE.error.unexpectedSettings": "неожиданная настройка OSE {configName}: {configValue}",
-  "OSE.error.cantDealDamageTo": "Невозможно нанести урон {nameOrId}"
+  "OSE.error.cantDealDamageTo": "Невозможно нанести урон {nameOrId}",
+  "TYPES.Base": "База",
+  "TYPES.Item.ability": "Способность",
+  "TYPES.Item.armor": "Доспехи",
+  "TYPES.Item.container": "Контейнер",
+  "TYPES.Item.item": "Предмет",
+  "TYPES.Item.spell": "Заклинание",
+  "TYPES.Item.weapon": "Оружие"
 }

--- a/src/lang/sv.json
+++ b/src/lang/sv.json
@@ -293,5 +293,12 @@
   "OSE.error.notEnoughGP": "Denna aktör har inte tillräckligt med GP för att betala för sin varukorg.",
   "OSE.error.itemNoLongerExistsOnActor": "Den begärda artikeln {itemId} finns inte längre på aktör {actorName}.",
   "OSE.error.noTokenControlled": "Du måste ha en eller flera kontrollerade aktörtokens för att kunna använda detta alternativ.",
-  "OSE.error.noGP": "Du behöver ett GP objekt för att använda denna funktion."
+  "OSE.error.noGP": "Du behöver ett GP objekt för att använda denna funktion.",
+  "TYPES.Base": "Bas",
+  "TYPES.Item.ability": "Färdighet",
+  "TYPES.Item.armor": "Rustning",
+  "TYPES.Item.container": "Behållare",
+  "TYPES.Item.item": "Föremål",
+  "TYPES.Item.spell": "Besvärjelse",
+  "TYPES.Item.weapon": "Vapen"
 }

--- a/src/lang/zh-CN.json
+++ b/src/lang/zh-CN.json
@@ -303,5 +303,12 @@
   "OSE.error.noTokenControlled": "您必须有一个或多个受控指示物才能使用此选项。",
   "OSE.error.noGP": "你需要 GP 物品来使用此功能。",
   "OSE.error.unexpectedSettings": "未预期的 OSE 设置 {configName}: {configValue}",
-  "OSE.error.cantDealDamageTo": "无法对 {nameOrId} 造成伤害"
+  "OSE.error.cantDealDamageTo": "无法对 {nameOrId} 造成伤害",
+  "TYPES.Base": "基础",
+  "TYPES.Item.ability": "能力",
+  "TYPES.Item.armor": "护甲",
+  "TYPES.Item.container": "容器",
+  "TYPES.Item.item": "物品",
+  "TYPES.Item.spell": "法术",
+  "TYPES.Item.weapon": "武器"
 }


### PR DESCRIPTION
### Why
I ran across a bug using the Item Piles v3.2.21 module.
Foundry: v13.346
Old-School Essentials: v2.1.2. 

You can see the item categories are broken.
<img width="600" height="497" alt="image" src="https://github.com/user-attachments/assets/90785460-fc0c-4646-875f-aa8ae56b3cfb" />

I did a little digging into the code and found that it relies on TYPES.Item.*" locale strings to be available, as retrieved from `CONFIG.Item.typeLabels`:
```javascript
// Console
CONFIG.Item.typeLabels
{
    "base": "TYPES.Base",
    "item": "TYPES.Item.item",
    "weapon": "TYPES.Item.weapon",
    "armor": "TYPES.Item.armor",
    "spell": "TYPES.Item.spell",
    "ability": "TYPES.Item.ability",
    "container": "TYPES.Item.container"
}
```
These strings seem to be expected to exist by convention in FoundryVTT. I even noted that the [dnd5e system adds these in its language files](https://github.com/foundryvtt/dnd5e/blob/5f51034dffecd60b971b70c584e166e64886f043/lang/en.json#L30-L57).


### Changes
I've added the missing strings to `en.json` at the bottom (observing alphabetical order). 


### Notes
* ~~I'm ignorant of how these get propagated to the other language files, but I noticed the `crowdin.yml` file which suggests it may be automated.~~ I filled out all the lang files with the missing Item type strings.
