### PR TITLE
Support tagging items as coins

### DIFF
--- a/src/module/item/data-model-item.js
+++ b/src/module/item/data-model-item.js
@@ -69,7 +69,15 @@ export default class OseDataModelItem extends foundry.abstract.TypeDataModel {
   get isCoinsOrGems() {
     if (!this.treasure) return false;
 
-    if (this.tags?.some((t) => t.value === "gem" || t.value === "gems")) {
+    if (
+      this.tags?.some(
+        (t) =>
+          t.value === "gem" ||
+          t.value === "gems" ||
+          t.value === "coin" ||
+          t.value === "coins"
+      )
+    ) {
       return true;
     }
 


### PR DESCRIPTION
Any item tagged as `coin` or `coins` will now count as coins (or gems) when calculating item based encumbrance.

Fixes #118 