### PR TITLE
fix: monster portraits being stretched out of ratio

### DIFF
--- a/src/scss/actor-base.scss
+++ b/src/scss/actor-base.scss
@@ -61,6 +61,8 @@
     .profile-img {
       border: 0;
       height: 140px;
+      object-fit: cover;
+      width: 100%;
     }
   }
 


### PR DESCRIPTION
fixes https://github.com/NecroticGnome/ose-foundry-premium-issues/issues/13