### PR TITLE
Fix Issue 135 - Text fields for items do not scale properly when the window is resized

### DIFF
--- a/src/scss/item.scss
+++ b/src/scss/item.scss
@@ -110,7 +110,7 @@
     }
     .description {
       .editor {
-        height: 250px;
+        height: auto;
         .editor-content {
           padding: 0 5px;
         }


### PR DESCRIPTION
### Text fields for items do not scale properly when the window is resized.

Fixes issue 135, where the descrpition field of items would be fixed to a height of 250px, regardless of the minimum height  needed to display the content without having to scroll.

See attachment for a short screencast to show the changes to the behavior of the item sheet.

[Screencast from 2026-01-30 00-14-33.webm](https://github.com/user-attachments/assets/7aa48d7a-c417-44dd-a1d8-0f3fb9f5ecec)

Fixes #35 
