### PR TITLE
Fix actor images not showing the entire image

### DIFF
--- a/src/scss/actor-base.scss
+++ b/src/scss/actor-base.scss
@@ -61,7 +61,7 @@
     .profile-img {
       border: 0;
       height: 140px;
-      object-fit: cover;
+      object-fit: contain;
       width: 100%;
     }
   }


### PR DESCRIPTION
Change object-fit from cover to contain for profile images

Relates to https://github.com/NecroticGnome/ose-foundry-premium-issues/issues/13