### PR TITLE
fix: pass HTMLElement to actor sheet ContextMenu

### DIFF
--- a/src/ose.js
+++ b/src/ose.js
@@ -193,11 +193,19 @@ Hooks.on("createCombatant", (combatant) => {
   combatant.assignGroup();
 });
 
+/**
+ * @param {Application} app - The actor sheet application
+ * @param {HTMLElement|JQuery} html - Sheet root (v1 hooks may still pass jQuery)
+ */
 Hooks.on("renderActorSheet", (app, html) => {
   if (!app?.object?.isOwnerOrObserver) return;
 
+  // ContextMenu no longer accepts jQuery roots (deprecated since Foundry v13).
+  const root = html instanceof HTMLElement ? html : html?.[0];
+  if (!(root instanceof HTMLElement)) return;
+
   new foundry.applications.ux.ContextMenu(
-    html,
+    root,
     ".item",
     [
       {


### PR DESCRIPTION
## Summary

- Fixes Foundry v13+ deprecation: `ContextMenu is changing to no longer transact jQuery objects. You must begin passing an HTMLElement instead.` when opening actor sheets.
- `renderActorSheet` still hands a jQuery object for ApplicationV1 sheets; normalize with `html instanceof HTMLElement ? html : html?.[0]` before constructing `foundry.applications.ux.ContextMenu`.
- Matches the existing pattern used for `renderCombatTracker` in the same file. Menu options already use `{ jQuery: false }`.

## Stack trace (before)

```
Error: ContextMenu is changing to no longer transact jQuery objects...
    at new ContextMenu (foundry.mjs)
    at Object.fn (ose.js)  // renderActorSheet hook
    at OseActorSheetCharacter._render
```

## Test plan

- [ ] Open a character sheet as GM/owner — no ContextMenu deprecation warning in the console
- [ ] Right-click inventory items — Show / Equip / Edit / Delete still work
- [ ] Open a monster sheet — same context menu behavior, no deprecation warning
- [ ] (Optional) Confirm combat tracker still works (unchanged path)