### PR TITLE
 Convert the item data models and Item entity to TypeScript

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,25 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js version 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run unit tests
+        run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "sass": "^1.97.2",
         "tslib": "^2.4.0",
         "typescript": "^5.9.3",
+        "vitest": "^5.0.0",
         "yargs": "^17.3.1"
       }
     },
@@ -604,6 +605,17 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.148.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.148.0.tgz",
+      "integrity": "sha512-Nm4s/jB+4FpFsPhWGEC4h7rzksesmtnMXomo6rCMcg/b8zLQuOziRgkCS1fxDCXOlJB/6Q8oABOZ/OP6RIPj9A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/oxc-project"
       }
     },
     "node_modules/@parcel/watcher": {
@@ -1414,6 +1426,284 @@
         "url": "^0.11.0"
       }
     },
+    "node_modules/@rolldown/binding-android-arm-eabi": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.7.tgz",
+      "integrity": "sha512-EypzgnYCwyVY4NDHKzGmNJT5b+XaQEBniHxsMdeIQLB/tcCzZnhqrzHpZFbX9iaxx+5RiB8caATBtfvZP7zVxQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.7.tgz",
+      "integrity": "sha512-l17HE9EweWaqJZhuUuNBN/FzM62xw+DECVnJyvMsxn8vJFAGLy5QfLDoYAcronkAN8VxKZHezDpulHDPx95vFw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.7.tgz",
+      "integrity": "sha512-8ED8ELFvHXc6OCETIn4gXObPiaR6bckM/ipXtbzlPVDRMBfEGjCKgO90F9YtfdpDatVx/ZQw7aZ1vUMf/+T3Mw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.7.tgz",
+      "integrity": "sha512-/WPripjtiAIZ2tWY7ddijORT0Ujg87wxWW/qcoFVCKAWVDPhtY0xr7Dj0M3GyNGz60jGwTElhro/mkF9dT7dDQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.7.tgz",
+      "integrity": "sha512-14DI4NcqpvbICxSnGLx3PmtDaWqRP/KGSGb6C+JLLVPeZRl6dKdHba3pGsqT3vpdTqhEYIPG0MMQ8c0xYqoJxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.7.tgz",
+      "integrity": "sha512-bxrWIRvHWQvbJwi+VIie/kDJmQxcNE6xxWwZdqF/ExVAigtHkv54WTLQPb+QsZdnFy18fg7JPfWGL0RH6vwIlQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.7.tgz",
+      "integrity": "sha512-toOY2BChBZyuxU7OYX6Tn389di4IzAqPTycVcci0O7FSfBqzRB3RZn+K5Is6ANf4tmgRd/K1yZTsNTXbkXsnLg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.7.tgz",
+      "integrity": "sha512-lAIXTH/aiLRLxsTgQvfhjo4K1ydWIp00+V0voOr9beb/9ZmkUFrSIb03dXNFRgMNvkE6oGsF10ioQ6UsI+vS5Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.7.tgz",
+      "integrity": "sha512-kdnwS28Pkenp/mZMRwjXXXwxQ7pIsm+bF919LUK93BOyhcLsrVKdP2p9fxpiPNPAbNuch8ypQt0pm2P2LYCAGg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.7.tgz",
+      "integrity": "sha512-516OdsyLdr5E65paF3yBF55t8mfm9+gmtCsK3xI7XKXIT7EfRlHhxL8K/NR6Hu8BWSgF5+1w74lTL0+nxcc8Qw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.7.tgz",
+      "integrity": "sha512-r8/z8n7GFaYRln3xmP1Cxy0HH/HLM0uBUPkEuSVEfKGDA89M0FsZRZJRSwe/tJjRx+fpH/gjorfhB8tmEbSFLA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.7.tgz",
+      "integrity": "sha512-pAsE8iiDxUg1xBqdhrTfg45AVDVpirjz00sblEYClGNNcMnDb+e8beQgqIAw6LvauX/APvgxUnwrgun/YYGBhw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.7.tgz",
+      "integrity": "sha512-lTcIYmmnQQA8Or/2DatS6oSqcdLHvendjS+zLu+FwgToynWMRSmQdpM65fTANJgIS4mjbMOo5KT2lnT9SAb96w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.7.tgz",
+      "integrity": "sha512-e3Gu3WxbNk/UqQhxqU7YIYO+9ZBvWNz3U+h/qRFosscMFzdRPbXYSaSWgSnklv2fz1TgzBTcti2z35c/7irsHw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.7.tgz",
+      "integrity": "sha512-W/jg5qoRSqjsEv0+dZi4e687mcHqmVuU0P4fK6qS/xjetW2Gmc1W8j//z5nAeNcC8Ttm0hV46IjcYeuVwYhuiw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@rollup/plugin-typescript": {
       "version": "12.3.0",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-12.3.0.tgz",
@@ -1463,13 +1753,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/@rollup/pluginutils/node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@rollup/pluginutils/node_modules/picomatch": {
       "version": "4.0.3",
@@ -1841,6 +2124,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/cors": {
       "version": "2.8.19",
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
@@ -1858,10 +2152,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/earcut": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/earcut/-/earcut-3.0.0.tgz",
       "integrity": "sha512-k/9fOUGO39yd2sCjrbAJvGDEQvRwRnQIZlBz43roGwUZo5SHAmyVvSFyaVVZkicRVCaDXPKlbxrUcBuJoSWunQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1913,10 +2221,14 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "17.0.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.18.tgz",
-      "integrity": "sha512-eKj4f/BsN/qcculZiRSujogjvp5O/k4lOW5m35NopjZM/QwLOR075a8pJW5hD+Rtdm2DaCVPENS6KtSQnUD6BA==",
-      "dev": true
+      "version": "26.4.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.1.tgz",
+      "integrity": "sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
     },
     "node_modules/@types/showdown": {
       "version": "2.0.6",
@@ -1957,6 +2269,64 @@
       "integrity": "sha512-d4GpH4uPYp9W07kc487tiq6V/EUHl18vZWFMbQoe4Sk9LXEWzFi/BMf9x7TI4m7/j7gU3KeX8H6M8aPBgykeLw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-5.0.0.tgz",
+      "integrity": "sha512-66PGTMIiVJP3t4a5yxU9qPtf7MdTBs8jmToMvy+HVflB3Yy13WJZTtPePdvU+wjRV02SKK5doLbSA6o9pwOmiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.31",
+        "@vitest/spy": "5.0.0",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^1.2.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/magic-string": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.2.3.tgz",
+      "integrity": "sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-5.0.0.tgz",
+      "integrity": "sha512-uy+luWBAPw9XfthoHi5AkfHUnuPYEESjl0p/r+meoBnU8bxg5GDQ3Ey8MjcJ6sqahkL4PFyrvfMJJBw7LbU06g==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -2062,6 +2432,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/async-function": {
@@ -2223,6 +2603,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -2465,7 +2855,6 @@
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -2732,6 +3121,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -2811,6 +3207,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/fast-glob": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.0.tgz",
@@ -2885,11 +3291,12 @@
       "dev": true
     },
     "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -3810,6 +4217,279 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "peer": true,
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/load-json-file": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
@@ -3948,9 +4628,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -4167,6 +4847,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -4360,9 +5054,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.28",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.28.tgz",
+      "integrity": "sha512-RRuzqDtt5Y9h3quz5hWhK+TPnsmVs6WwSU6LkJMeY4HstUEDuYTG8UJSdawMRzmzAtV+KEoG8N3Qg2qLy5vM/A==",
       "dev": true,
       "funding": [
         {
@@ -4380,7 +5074,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.18",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -4690,6 +5384,41 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.7.tgz",
+      "integrity": "sha512-g0EtLvBjTUB7jhyV0S/TCup3v/XSVl45vUIGbOGU4QPiyjTenCe4mKuFvW9fEgYmS2Fo42AUssRmNuMziXdrig==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@oxc-project/types": "=0.148.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm-eabi": "1.2.7",
+        "@rolldown/binding-android-arm64": "1.2.7",
+        "@rolldown/binding-darwin-arm64": "1.2.7",
+        "@rolldown/binding-darwin-x64": "1.2.7",
+        "@rolldown/binding-freebsd-x64": "1.2.7",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.7",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.7",
+        "@rolldown/binding-linux-arm64-musl": "1.2.7",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.7",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.7",
+        "@rolldown/binding-linux-x64-gnu": "1.2.7",
+        "@rolldown/binding-linux-x64-musl": "1.2.7",
+        "@rolldown/binding-openharmony-arm64": "1.2.7",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.7",
+        "@rolldown/binding-win32-x64-msvc": "1.2.7"
       }
     },
     "node_modules/rollup": {
@@ -5176,6 +5905,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/simple-peer": {
       "version": "9.11.1",
       "resolved": "https://registry.npmjs.org/simple-peer/-/simple-peer-9.11.1.tgz",
@@ -5343,6 +6079,20 @@
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
       "integrity": "sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==",
       "dev": true
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -5512,6 +6262,74 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tinybench": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-6.1.4.tgz",
+      "integrity": "sha512-9APumHG7r4yOk4X4WlkmE71aZcv1gvin1czO3OQ1U9iJcFA5Ja/ygyb0vPOVHTthFozUYs8CLoLUlM8grb2lTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/tinymce": {
       "version": "6.8.6",
       "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-6.8.6.tgz",
@@ -5662,6 +6480,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -5710,6 +6535,205 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.2.tgz",
+      "integrity": "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.26",
+        "rolldown": "~1.2.4",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.4.0 || ^0.5.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-5.0.0.tgz",
+      "integrity": "sha512-gpsMNoRhMjMktVxPtstOH4/PJuPyovVaMDr4oDilXaGH1EcqM2OE96SoHT2VIQ6fTGtTjqmHDrEu2X9RQiXf8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/mocker": "5.0.0",
+        "chai": "^6.2.2",
+        "es-module-lexer": "^2.3.2",
+        "expect-type": "^1.4.0",
+        "magic-string": "^1.2.3",
+        "obug": "^2.1.4",
+        "picomatch": "^4.0.7",
+        "std-env": "^4.2.0",
+        "tinybench": "6.1.4",
+        "tinyexec": "1.3.0",
+        "tinyglobby": "^0.2.17",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^22.12.0 || ^24.0.0 || >=26.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "5.0.0",
+        "@vitest/browser-preview": "5.0.0",
+        "@vitest/browser-webdriverio": "^5.0.0-beta.5 || >=5.0.0",
+        "@vitest/coverage-istanbul": "5.0.0",
+        "@vitest/coverage-v8": "5.0.0",
+        "@vitest/ui": "5.0.0",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.4.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/magic-string": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.2.3.tgz",
+      "integrity": "sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/w3c-keyname": {
@@ -5818,6 +6842,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wordwrap": {
@@ -6393,6 +7434,13 @@
         "fastq": "^1.6.0"
       }
     },
+    "@oxc-project/types": {
+      "version": "0.148.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.148.0.tgz",
+      "integrity": "sha512-Nm4s/jB+4FpFsPhWGEC4h7rzksesmtnMXomo6rCMcg/b8zLQuOziRgkCS1fxDCXOlJB/6Q8oABOZ/OP6RIPj9A==",
+      "dev": true,
+      "peer": true
+    },
     "@parcel/watcher": {
       "version": "2.5.4",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.4.tgz",
@@ -6840,6 +7888,133 @@
         "url": "^0.11.0"
       }
     },
+    "@rolldown/binding-android-arm-eabi": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.7.tgz",
+      "integrity": "sha512-EypzgnYCwyVY4NDHKzGmNJT5b+XaQEBniHxsMdeIQLB/tcCzZnhqrzHpZFbX9iaxx+5RiB8caATBtfvZP7zVxQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
+    "@rolldown/binding-android-arm64": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.7.tgz",
+      "integrity": "sha512-l17HE9EweWaqJZhuUuNBN/FzM62xw+DECVnJyvMsxn8vJFAGLy5QfLDoYAcronkAN8VxKZHezDpulHDPx95vFw==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
+    "@rolldown/binding-darwin-arm64": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.7.tgz",
+      "integrity": "sha512-8ED8ELFvHXc6OCETIn4gXObPiaR6bckM/ipXtbzlPVDRMBfEGjCKgO90F9YtfdpDatVx/ZQw7aZ1vUMf/+T3Mw==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
+    "@rolldown/binding-darwin-x64": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.7.tgz",
+      "integrity": "sha512-/WPripjtiAIZ2tWY7ddijORT0Ujg87wxWW/qcoFVCKAWVDPhtY0xr7Dj0M3GyNGz60jGwTElhro/mkF9dT7dDQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
+    "@rolldown/binding-freebsd-x64": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.7.tgz",
+      "integrity": "sha512-14DI4NcqpvbICxSnGLx3PmtDaWqRP/KGSGb6C+JLLVPeZRl6dKdHba3pGsqT3vpdTqhEYIPG0MMQ8c0xYqoJxA==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
+    "@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.7.tgz",
+      "integrity": "sha512-bxrWIRvHWQvbJwi+VIie/kDJmQxcNE6xxWwZdqF/ExVAigtHkv54WTLQPb+QsZdnFy18fg7JPfWGL0RH6vwIlQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
+    "@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.7.tgz",
+      "integrity": "sha512-toOY2BChBZyuxU7OYX6Tn389di4IzAqPTycVcci0O7FSfBqzRB3RZn+K5Is6ANf4tmgRd/K1yZTsNTXbkXsnLg==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
+    "@rolldown/binding-linux-arm64-musl": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.7.tgz",
+      "integrity": "sha512-lAIXTH/aiLRLxsTgQvfhjo4K1ydWIp00+V0voOr9beb/9ZmkUFrSIb03dXNFRgMNvkE6oGsF10ioQ6UsI+vS5Q==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
+    "@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.7.tgz",
+      "integrity": "sha512-kdnwS28Pkenp/mZMRwjXXXwxQ7pIsm+bF919LUK93BOyhcLsrVKdP2p9fxpiPNPAbNuch8ypQt0pm2P2LYCAGg==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
+    "@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.7.tgz",
+      "integrity": "sha512-516OdsyLdr5E65paF3yBF55t8mfm9+gmtCsK3xI7XKXIT7EfRlHhxL8K/NR6Hu8BWSgF5+1w74lTL0+nxcc8Qw==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
+    "@rolldown/binding-linux-x64-gnu": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.7.tgz",
+      "integrity": "sha512-r8/z8n7GFaYRln3xmP1Cxy0HH/HLM0uBUPkEuSVEfKGDA89M0FsZRZJRSwe/tJjRx+fpH/gjorfhB8tmEbSFLA==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
+    "@rolldown/binding-linux-x64-musl": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.7.tgz",
+      "integrity": "sha512-pAsE8iiDxUg1xBqdhrTfg45AVDVpirjz00sblEYClGNNcMnDb+e8beQgqIAw6LvauX/APvgxUnwrgun/YYGBhw==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
+    "@rolldown/binding-openharmony-arm64": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.7.tgz",
+      "integrity": "sha512-lTcIYmmnQQA8Or/2DatS6oSqcdLHvendjS+zLu+FwgToynWMRSmQdpM65fTANJgIS4mjbMOo5KT2lnT9SAb96w==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
+    "@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.7.tgz",
+      "integrity": "sha512-e3Gu3WxbNk/UqQhxqU7YIYO+9ZBvWNz3U+h/qRFosscMFzdRPbXYSaSWgSnklv2fz1TgzBTcti2z35c/7irsHw==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
+    "@rolldown/binding-win32-x64-msvc": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.7.tgz",
+      "integrity": "sha512-W/jg5qoRSqjsEv0+dZi4e687mcHqmVuU0P4fK6qS/xjetW2Gmc1W8j//z5nAeNcC8Ttm0hV46IjcYeuVwYhuiw==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
+    "@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "peer": true
+    },
     "@rollup/plugin-typescript": {
       "version": "12.3.0",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-12.3.0.tgz",
@@ -6861,12 +8036,6 @@
         "picomatch": "^4.0.2"
       },
       "dependencies": {
-        "@types/estree": {
-          "version": "1.0.8",
-          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-          "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-          "dev": true
-        },
         "picomatch": {
           "version": "4.0.3",
           "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
@@ -7056,6 +8225,16 @@
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
       "dev": true
     },
+    "@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "requires": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "@types/cors": {
       "version": "2.8.19",
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
@@ -7071,10 +8250,22 @@
       "integrity": "sha512-x2tZZYkSxXqWvTDgveSynfjq/T2HyiZHXb00j/+gy19yp70PHCizM48XFdjBCWH7eHBD0R5i/pw9yMBP/BH5uA==",
       "dev": true
     },
+    "@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true
+    },
     "@types/earcut": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/earcut/-/earcut-3.0.0.tgz",
       "integrity": "sha512-k/9fOUGO39yd2sCjrbAJvGDEQvRwRnQIZlBz43roGwUZo5SHAmyVvSFyaVVZkicRVCaDXPKlbxrUcBuJoSWunQ==",
+      "dev": true
+    },
+    "@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true
     },
     "@types/fs-extra": {
@@ -7121,10 +8312,13 @@
       "dev": true
     },
     "@types/node": {
-      "version": "17.0.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.18.tgz",
-      "integrity": "sha512-eKj4f/BsN/qcculZiRSujogjvp5O/k4lOW5m35NopjZM/QwLOR075a8pJW5hD+Rtdm2DaCVPENS6KtSQnUD6BA==",
-      "dev": true
+      "version": "26.4.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.1.tgz",
+      "integrity": "sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~8.3.0"
+      }
     },
     "@types/showdown": {
       "version": "2.0.6",
@@ -7160,6 +8354,44 @@
       "version": "0.0.50",
       "resolved": "https://registry.npmjs.org/@types/youtube/-/youtube-0.0.50.tgz",
       "integrity": "sha512-d4GpH4uPYp9W07kc487tiq6V/EUHl18vZWFMbQoe4Sk9LXEWzFi/BMf9x7TI4m7/j7gU3KeX8H6M8aPBgykeLw==",
+      "dev": true
+    },
+    "@vitest/mocker": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-5.0.0.tgz",
+      "integrity": "sha512-66PGTMIiVJP3t4a5yxU9qPtf7MdTBs8jmToMvy+HVflB3Yy13WJZTtPePdvU+wjRV02SKK5doLbSA6o9pwOmiA==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/trace-mapping": "0.3.31",
+        "@vitest/spy": "5.0.0",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^1.2.3"
+      },
+      "dependencies": {
+        "estree-walker": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+          "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+          "dev": true,
+          "requires": {
+            "@types/estree": "^1.0.0"
+          }
+        },
+        "magic-string": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.2.3.tgz",
+          "integrity": "sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g==",
+          "dev": true,
+          "requires": {
+            "@jridgewell/sourcemap-codec": "^1.5.5"
+          }
+        }
+      }
+    },
+    "@vitest/spy": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-5.0.0.tgz",
+      "integrity": "sha512-uy+luWBAPw9XfthoHi5AkfHUnuPYEESjl0p/r+meoBnU8bxg5GDQ3Ey8MjcJ6sqahkL4PFyrvfMJJBw7LbU06g==",
       "dev": true
     },
     "accepts": {
@@ -7234,6 +8466,12 @@
         "get-intrinsic": "^1.2.6",
         "is-array-buffer": "^3.0.4"
       }
+    },
+    "assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true
     },
     "async-function": {
       "version": "1.0.0",
@@ -7328,6 +8566,12 @@
         "call-bind-apply-helpers": "^1.0.2",
         "get-intrinsic": "^1.3.0"
       }
+    },
+    "chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true
     },
     "chalk": {
       "version": "2.4.2",
@@ -7501,8 +8745,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "dir-glob": {
       "version": "3.0.1",
@@ -7704,6 +8947,12 @@
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "dev": true
     },
+    "es-module-lexer": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+      "dev": true
+    },
     "es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -7758,6 +9007,12 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "dev": true
+    },
+    "expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
       "dev": true
     },
     "fast-glob": {
@@ -7818,9 +9073,9 @@
       "dev": true
     },
     "fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
       "optional": true
     },
@@ -8413,6 +9668,115 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "detect-libc": "^2.0.3",
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
+    "lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
+    "lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
+    "lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
+    "lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
+    "lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
+    "lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
+    "lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
+    "lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
+    "lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
+    "lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
     "load-json-file": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
@@ -8511,9 +9875,9 @@
       "dev": true
     },
     "nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true
     },
     "negotiator": {
@@ -8658,6 +10022,12 @@
         "object-keys": "^1.1.1"
       }
     },
+    "obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -8794,12 +10164,12 @@
       "dev": true
     },
     "postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.28",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.28.tgz",
+      "integrity": "sha512-RRuzqDtt5Y9h3quz5hWhK+TPnsmVs6WwSU6LkJMeY4HstUEDuYTG8UJSdawMRzmzAtV+KEoG8N3Qg2qLy5vM/A==",
       "dev": true,
       "requires": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.18",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       }
@@ -9036,6 +10406,32 @@
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
       "dev": true
+    },
+    "rolldown": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.7.tgz",
+      "integrity": "sha512-g0EtLvBjTUB7jhyV0S/TCup3v/XSVl45vUIGbOGU4QPiyjTenCe4mKuFvW9fEgYmS2Fo42AUssRmNuMziXdrig==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@oxc-project/types": "=0.148.0",
+        "@rolldown/binding-android-arm-eabi": "1.2.7",
+        "@rolldown/binding-android-arm64": "1.2.7",
+        "@rolldown/binding-darwin-arm64": "1.2.7",
+        "@rolldown/binding-darwin-x64": "1.2.7",
+        "@rolldown/binding-freebsd-x64": "1.2.7",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.7",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.7",
+        "@rolldown/binding-linux-arm64-musl": "1.2.7",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.7",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.7",
+        "@rolldown/binding-linux-x64-gnu": "1.2.7",
+        "@rolldown/binding-linux-x64-musl": "1.2.7",
+        "@rolldown/binding-openharmony-arm64": "1.2.7",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.7",
+        "@rolldown/binding-win32-x64-msvc": "1.2.7",
+        "@rolldown/pluginutils": "^1.0.0"
+      }
     },
     "rollup": {
       "version": "4.55.1",
@@ -9350,6 +10746,12 @@
         "side-channel-map": "^1.0.1"
       }
     },
+    "siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
     "simple-peer": {
       "version": "9.11.1",
       "resolved": "https://registry.npmjs.org/simple-peer/-/simple-peer-9.11.1.tgz",
@@ -9474,6 +10876,18 @@
       "integrity": "sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==",
       "dev": true
     },
+    "stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
+    "std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true
+    },
     "stop-iteration-iterator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
@@ -9590,6 +11004,43 @@
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true
     },
+    "tinybench": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-6.1.4.tgz",
+      "integrity": "sha512-9APumHG7r4yOk4X4WlkmE71aZcv1gvin1czO3OQ1U9iJcFA5Ja/ygyb0vPOVHTthFozUYs8CLoLUlM8grb2lTQ==",
+      "dev": true
+    },
+    "tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true
+    },
+    "tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "requires": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "dependencies": {
+        "fdir": {
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+          "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+          "dev": true,
+          "requires": {}
+        },
+        "picomatch": {
+          "version": "4.0.7",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+          "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+          "dev": true
+        }
+      }
+    },
     "tinymce": {
       "version": "6.8.6",
       "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-6.8.6.tgz",
@@ -9689,6 +11140,12 @@
         "which-boxed-primitive": "^1.1.1"
       }
     },
+    "undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true
+    },
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -9726,6 +11183,68 @@
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "dev": true
+    },
+    "vite": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.2.tgz",
+      "integrity": "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "fsevents": "~2.3.3",
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.26",
+        "rolldown": "~1.2.4",
+        "tinyglobby": "^0.2.17"
+      },
+      "dependencies": {
+        "picomatch": {
+          "version": "4.0.7",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+          "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+          "dev": true,
+          "peer": true
+        }
+      }
+    },
+    "vitest": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-5.0.0.tgz",
+      "integrity": "sha512-gpsMNoRhMjMktVxPtstOH4/PJuPyovVaMDr4oDilXaGH1EcqM2OE96SoHT2VIQ6fTGtTjqmHDrEu2X9RQiXf8Q==",
+      "dev": true,
+      "requires": {
+        "@types/chai": "^5.2.2",
+        "@vitest/mocker": "5.0.0",
+        "chai": "^6.2.2",
+        "es-module-lexer": "^2.3.2",
+        "expect-type": "^1.4.0",
+        "magic-string": "^1.2.3",
+        "obug": "^2.1.4",
+        "picomatch": "^4.0.7",
+        "std-env": "^4.2.0",
+        "tinybench": "6.1.4",
+        "tinyexec": "1.3.0",
+        "tinyglobby": "^0.2.17",
+        "why-is-node-running": "^2.3.0"
+      },
+      "dependencies": {
+        "magic-string": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.2.3.tgz",
+          "integrity": "sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g==",
+          "dev": true,
+          "requires": {
+            "@jridgewell/sourcemap-codec": "^1.5.5"
+          }
+        },
+        "picomatch": {
+          "version": "4.0.7",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+          "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+          "dev": true
+        }
+      }
     },
     "w3c-keyname": {
       "version": "2.2.8",
@@ -9801,6 +11320,16 @@
         "get-proto": "^1.0.1",
         "gopd": "^1.2.0",
         "has-tostringtag": "^1.0.2"
+      }
+    },
+    "why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "requires": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
       }
     },
     "wordwrap": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "watch:js": "rollup -c --watch",
     "watch:css": "sass --watch src/ose.scss dist/ose.css --source-map",
     "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "link": "node ./tools/symlink.js",
     "unlink": "node ./tools/symlink.js -c",
     "lint": "biome check src",
@@ -36,6 +38,7 @@
     "sass": "^1.97.2",
     "tslib": "^2.4.0",
     "typescript": "^5.9.3",
+    "vitest": "^5.0.0",
     "yargs": "^17.3.1"
   }
 }

--- a/src/module/config.ts
+++ b/src/module/config.ts
@@ -38,6 +38,9 @@ export type Color = keyof OseConfig["colors"];
 /** A weapon/item quality tag key (e.g. `melee`, `missile`, `slow`, `twohanded`). */
 export type InventoryItemTag = keyof OseConfig["tags"];
 
+/** A tag's stored value: the localization key it is saved as, e.g. `OSE.items.Blunt`. */
+export type InventoryItemTagValue = OseConfig["tags"][InventoryItemTag];
+
 /** An encumbrance-scheme key: `basic`, `detailed`, `complete`, `disabled`, or `itembased`. */
 export type EncumbranceOption = keyof OseConfig["encumbranceOptions"];
 
@@ -195,7 +198,7 @@ export const OSE = {
     splash: "OSE.items.Splash",
     reload: "OSE.items.Reload",
     charge: "OSE.items.Charge",
-  },
+  } as const,
   /** Display metadata (label, image, icon) for each item tag, derived on access. */
   auto_tags: {
     get melee() {

--- a/src/module/helpers-tags.ts
+++ b/src/module/helpers-tags.ts
@@ -2,6 +2,8 @@
  * @file Contains helpers for tag generation
  */
 
+import type { RollType } from "./config";
+
 const OseTags = {
   /**
    * Returns the formula used for dice roll calculations
@@ -9,18 +11,13 @@ const OseTags = {
    * @param data.roll - The string used to generate a formula
    * @returns tagFormula - The constructed roll formula
    */
-  rollTagFormula({
-    actor = {},
-    data = {
-      roll: "",
-    },
-  } = {}) {
+  rollTagFormula({ actor = {}, data = { roll: "" } }: { actor?: unknown; data?: { roll?: string } } = {}) {
     const formulaData = {
       actor,
       data,
     };
 
-    const tagFormula = new Roll(data.roll, formulaData).formula;
+    const tagFormula = new Roll(data.roll ?? "", formulaData).formula;
     return tagFormula;
   },
 
@@ -29,8 +26,9 @@ const OseTags = {
    * @param rollType - Type of roll target used
    * @returns tagTarget - The constructed type and target value
    */
-  rollTagTarget({ rollType = "" as keyof typeof CONFIG.OSE.roll_type, rollTarget = null } = {}) {
-    const tagTarget = rollTarget === null ? "" : ` ${CONFIG.OSE.roll_type[rollType]}${rollTarget}`;
+  rollTagTarget({ rollType = "", rollTarget = null }: { rollType?: RollType | ""; rollTarget?: number | null } = {}) {
+    // Indexing with "" yields undefined, which the original relies on; preserved.
+    const tagTarget = rollTarget === null ? "" : ` ${CONFIG.OSE.roll_type[rollType as RollType]}${rollTarget}`;
 
     return tagTarget;
   },

--- a/src/module/item/__tests__/data-model-ability.unit.test.ts
+++ b/src/module/item/__tests__/data-model-ability.unit.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import OseDataModelAbility from "../data-model-ability";
+
+describe("OseDataModelAbility", () => {
+  describe("schema defaults", () => {
+    it("initializes fields from defineSchema", () => {
+      const ability = new OseDataModelAbility();
+
+      expect(ability.save).toBe("");
+      expect(ability.pattern).toBe("");
+      expect(ability.requirements).toBe("");
+      expect(ability.roll).toBe("");
+      expect(ability.rollType).toBe("");
+      expect(ability.rollTarget).toBeNull();
+      expect(ability.blindroll).toBe(false);
+      expect(ability.description).toBe("");
+      expect(ability.tags).toEqual([]);
+    });
+  });
+
+  describe("manualTags", () => {
+    it("returns stored tags unchanged, with no label added", () => {
+      const ability = new OseDataModelAbility({ tags: [{ title: "title", value: "value" }] });
+
+      expect(ability.manualTags).toEqual([{ title: "title", value: "value" }]);
+    });
+
+    it("returns an empty array by default", () => {
+      expect(new OseDataModelAbility().manualTags).toEqual([]);
+    });
+
+    it("returns an empty array rather than null when tags is absent", () => {
+      const ability = new OseDataModelAbility();
+      ability.tags = undefined as never;
+
+      expect(ability.manualTags).toEqual([]);
+    });
+  });
+
+  describe("autoTags", () => {
+    it("still yields one empty tag by default, since ''.split(',') is ['']", () => {
+      expect(new OseDataModelAbility().autoTags).toEqual([{ label: "" }]);
+    });
+
+    it("splits requirements on commas into one tag each", () => {
+      const ability = new OseDataModelAbility({ requirements: "magic-user,slow" });
+
+      expect(ability.autoTags).toEqual([{ label: "magic-user" }, { label: "slow" }]);
+    });
+
+    it("trims whitespace around each requirement", () => {
+      const ability = new OseDataModelAbility({ requirements: " magic-user , slow " });
+
+      expect(ability.autoTags).toEqual([{ label: "magic-user" }, { label: "slow" }]);
+    });
+
+    it("appends a save tag with a skull icon", () => {
+      const ability = new OseDataModelAbility({ save: "death" });
+
+      expect(ability.autoTags).toEqual([{ label: "" }, { label: CONFIG.OSE.saves_long.death, icon: "fa-skull" }]);
+    });
+
+    it("appends a roll tag carrying the formula and the roll target", () => {
+      const ability = new OseDataModelAbility({ roll: "1d20+1", rollType: "result", rollTarget: 15 });
+
+      expect(ability.autoTags).toEqual([{ label: "" }, { label: "OSE.items.Roll 1d20+1 =15" }]);
+    });
+
+    it("orders requirements, then roll, then save", () => {
+      const ability = new OseDataModelAbility({ requirements: "cleric", roll: "1d6", save: "death" });
+
+      expect(ability.autoTags).toHaveLength(3);
+      expect(ability.autoTags[0]).toEqual({ label: "cleric" });
+      expect(ability.autoTags[1]?.label).toContain("1d6");
+      expect(ability.autoTags[2]).toEqual({ label: CONFIG.OSE.saves_long.death, icon: "fa-skull" });
+    });
+  });
+});

--- a/src/module/item/__tests__/data-model-armor.unit.test.ts
+++ b/src/module/item/__tests__/data-model-armor.unit.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import OseDataModelArmor from "../data-model-armor";
+
+describe("OseDataModelArmor", () => {
+  describe("ArmorTypes", () => {
+    it("exposes exactly the four armor types", () => {
+      expect(OseDataModelArmor.ArmorTypes).toEqual({
+        unarmored: "OSE.armor.unarmored",
+        light: "OSE.armor.light",
+        heavy: "OSE.armor.heavy",
+        shield: "OSE.armor.shield",
+      });
+    });
+  });
+
+  describe("schema defaults", () => {
+    it("initializes fields from defineSchema", () => {
+      const armor = new OseDataModelArmor();
+
+      expect(armor.type).toBe("light");
+      expect(armor.ac).toEqual({ value: 9 });
+      expect(armor.aac).toEqual({ value: 10 });
+      expect(armor.tags).toEqual([]);
+      expect(armor.equipped).toBe(false);
+      expect(armor.description).toBe("");
+      expect(armor.containerId).toBe("");
+      expect(armor.cost).toBe(0);
+      expect(armor.weight).toBe(0);
+      expect(armor.itemslots).toBe(1);
+      expect(armor.quantity).toEqual({ value: 0, max: 0 });
+    });
+  });
+
+  describe("manualTags", () => {
+    it("returns an empty array by default", () => {
+      expect(new OseDataModelArmor().manualTags).toEqual([]);
+    });
+
+    it("echoes a stored tag back with label set to its value", () => {
+      const armor = new OseDataModelArmor({
+        tags: [{ title: "title", value: "value" }],
+      });
+
+      expect(armor.manualTags).toEqual([{ title: "title", value: "value", label: "value" }]);
+    });
+
+    it("leaves the stored tag itself untouched", () => {
+      const armor = new OseDataModelArmor({
+        tags: [{ title: "title", value: "value" }],
+      });
+
+      expect(armor.tags).toEqual([{ title: "title", value: "value" }]);
+    });
+
+    it("omits tags whose value matches a known auto-tag", () => {
+      const armor = new OseDataModelArmor({
+        tags: [{ value: CONFIG.OSE.tags.blunt }],
+      });
+
+      expect(armor.manualTags).toEqual([]);
+    });
+
+    it("returns null when tags is absent entirely", () => {
+      const armor = new OseDataModelArmor();
+      armor.tags = undefined as never;
+
+      expect(armor.manualTags).toBeNull();
+    });
+  });
+
+  describe("autoTags", () => {
+    it("always leads with the armor type and a tshirt icon", () => {
+      const armor = new OseDataModelArmor();
+
+      expect(armor.autoTags).toEqual([{ label: "OSE.armor.light", icon: "fa-tshirt" }]);
+    });
+
+    it("reflects a non-default armor type", () => {
+      const armor = new OseDataModelArmor({ type: "shield" });
+
+      expect(armor.autoTags[0]).toEqual({
+        label: "OSE.armor.shield",
+        icon: "fa-tshirt",
+      });
+    });
+
+    it("resolves a known tag value to its display metadata", () => {
+      const armor = new OseDataModelArmor({
+        tags: [{ value: CONFIG.OSE.tags.blunt }],
+      });
+
+      expect(armor.autoTags).toHaveLength(2);
+      expect(armor.autoTags[1]).toMatchObject({
+        label: CONFIG.OSE.tags.blunt,
+        icon: "fa-hammer-crash",
+        image: `${CONFIG.OSE.assetsPath}/blunt.png`,
+      });
+    });
+
+    it("appends unknown tags after the armor type", () => {
+      const armor = new OseDataModelArmor({ tags: [{ value: "homebrew" }] });
+
+      expect(armor.autoTags).toEqual([
+        { label: "OSE.armor.light", icon: "fa-tshirt" },
+        { title: undefined, value: "homebrew", label: "homebrew" },
+      ]);
+    });
+  });
+});

--- a/src/module/item/__tests__/data-model-container.unit.test.ts
+++ b/src/module/item/__tests__/data-model-container.unit.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import OseDataModelContainer from "../data-model-container";
+
+const CONTAINER_ID = "container-1";
+
+const carried = (containerId: string, weight: number, quantity?: { value: number }) => ({
+  system: { containerId, weight, quantity },
+});
+
+/** An Item document standing in for the container's `parent`, owned by an Actor. */
+const parentIn = (items: unknown[]) => ({
+  id: CONTAINER_ID,
+  parent: { items },
+});
+
+describe("OseDataModelContainer", () => {
+  describe("schema defaults", () => {
+    it("initializes fields from defineSchema", () => {
+      const container = new OseDataModelContainer();
+
+      expect(container.itemIds).toEqual([]);
+      expect(container.tags).toEqual([]);
+      expect(container.equipped).toBe(false);
+      expect(container.description).toBe("");
+      expect(container.containerId).toBe("");
+      expect(container.cost).toBe(0);
+      expect(container.weight).toBe(0);
+      expect(container.itemslots).toBe(1);
+      expect(container.quantity).toEqual({ value: 0, max: 0 });
+    });
+  });
+
+  describe("contents", () => {
+    it("is null when the container has no parent Actor", () => {
+      expect(new OseDataModelContainer().contents).toBeNull();
+    });
+
+    it("returns only the Actor's items whose containerId matches", () => {
+      const mine = carried(CONTAINER_ID, 5);
+      const theirs = carried("some-other-container", 3);
+      const loose = carried("", 1);
+      const container = new OseDataModelContainer({}, { parent: parentIn([mine, theirs, loose]) });
+
+      expect(container.contents).toEqual([mine]);
+    });
+
+    it("is an empty array when the Actor carries nothing of ours", () => {
+      const container = new OseDataModelContainer({}, { parent: parentIn([carried("elsewhere", 9)]) });
+
+      expect(container.contents).toEqual([]);
+    });
+  });
+
+  describe("totalWeight", () => {
+    it("is 0 with no parent Actor", () => {
+      expect(new OseDataModelContainer().totalWeight).toBe(0);
+    });
+
+    it("multiplies each item's weight by its quantity", () => {
+      const container = new OseDataModelContainer(
+        {},
+        { parent: parentIn([carried(CONTAINER_ID, 5, { value: 3 }), carried(CONTAINER_ID, 2, { value: 4 })]) },
+      );
+
+      expect(container.totalWeight).toBe(23);
+    });
+
+    it("counts an item with no quantity as one", () => {
+      const container = new OseDataModelContainer({}, { parent: parentIn([carried(CONTAINER_ID, 7)]) });
+
+      expect(container.totalWeight).toBe(7);
+    });
+
+    it("counts a zero quantity as one, since the fallback is falsy-based", () => {
+      const container = new OseDataModelContainer({}, { parent: parentIn([carried(CONTAINER_ID, 7, { value: 0 })]) });
+
+      expect(container.totalWeight).toBe(7);
+    });
+  });
+
+  describe("manualTags", () => {
+    it("returns an empty array by default", () => {
+      expect(new OseDataModelContainer().manualTags).toEqual([]);
+    });
+
+    it("echoes a stored tag back with label set to its value", () => {
+      const container = new OseDataModelContainer({ tags: [{ title: "title", value: "value" }] });
+
+      expect(container.manualTags).toEqual([{ title: "title", value: "value", label: "value" }]);
+    });
+
+    it("omits tags whose value matches a known auto-tag", () => {
+      const container = new OseDataModelContainer({ tags: [{ value: CONFIG.OSE.tags.blunt }] });
+
+      expect(container.manualTags).toEqual([]);
+    });
+
+    it("returns null when tags is absent entirely", () => {
+      const container = new OseDataModelContainer();
+      container.tags = undefined as never;
+
+      expect(container.manualTags).toBeNull();
+    });
+  });
+
+  describe("autoTags", () => {
+    it("returns no auto-tags by default", () => {
+      expect(new OseDataModelContainer().autoTags).toEqual([]);
+    });
+
+    it("resolves a known tag value to its display metadata", () => {
+      const container = new OseDataModelContainer({ tags: [{ value: CONFIG.OSE.tags.blunt }] });
+
+      expect(container.autoTags).toEqual([CONFIG.OSE.auto_tags.blunt]);
+    });
+
+    it("passes unknown tags through as manual tags", () => {
+      const container = new OseDataModelContainer({ tags: [{ value: "homebrew" }] });
+
+      expect(container.autoTags).toEqual([{ title: undefined, value: "homebrew", label: "homebrew" }]);
+    });
+  });
+});

--- a/src/module/item/__tests__/data-model-item.unit.test.ts
+++ b/src/module/item/__tests__/data-model-item.unit.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import OseDataModelItem from "../data-model-item";
+
+describe("OseDataModelItem", () => {
+  describe("schema defaults", () => {
+    it("initializes fields from defineSchema", () => {
+      const item = new OseDataModelItem();
+
+      expect(item.tags).toEqual([]);
+      expect(item.treasure).toBe(false);
+      expect(item.equipped).toBe(false);
+      expect(item.description).toBe("");
+      expect(item.containerId).toBe("");
+      expect(item.cost).toBe(0);
+      expect(item.weight).toBe(0);
+      expect(item.itemslots).toBe(0);
+      expect(item.quantity).toEqual({ value: 1, max: 0 });
+    });
+  });
+
+  describe("manualTags", () => {
+    it("returns an empty array by default", () => {
+      expect(new OseDataModelItem().manualTags).toEqual([]);
+    });
+
+    it("echoes a stored tag back with label set to its value", () => {
+      const item = new OseDataModelItem({ tags: [{ title: "title", value: "value" }] });
+
+      expect(item.manualTags).toEqual([{ title: "title", value: "value", label: "value" }]);
+    });
+
+    it("omits tags whose value matches a known auto-tag", () => {
+      const item = new OseDataModelItem({ tags: [{ value: CONFIG.OSE.tags.blunt }] });
+
+      expect(item.manualTags).toEqual([]);
+    });
+
+    it("returns null when tags is absent entirely", () => {
+      const item = new OseDataModelItem();
+      item.tags = undefined as never;
+
+      expect(item.manualTags).toBeNull();
+    });
+  });
+
+  describe("autoTags", () => {
+    it("returns no auto-tags by default", () => {
+      expect(new OseDataModelItem().autoTags).toEqual([]);
+    });
+
+    it("resolves a known tag value to its display metadata", () => {
+      const item = new OseDataModelItem({ tags: [{ value: CONFIG.OSE.tags.blunt }] });
+
+      expect(item.autoTags).toHaveLength(1);
+      expect(item.autoTags[0]).toMatchObject({
+        label: CONFIG.OSE.tags.blunt,
+        icon: "fa-hammer-crash",
+        image: `${CONFIG.OSE.assetsPath}/blunt.png`,
+      });
+    });
+
+    it("passes unknown tags through as manual tags", () => {
+      const item = new OseDataModelItem({ tags: [{ value: "homebrew" }] });
+
+      expect(item.autoTags).toEqual([{ title: undefined, value: "homebrew", label: "homebrew" }]);
+    });
+  });
+
+  describe("cumulative getters", () => {
+    it("multiplies weight, cost, and itemslots by quantity", () => {
+      const item = new OseDataModelItem({
+        weight: 5,
+        cost: 12,
+        itemslots: 0.5,
+        quantity: { value: 3, max: 0 },
+      });
+
+      expect(item.cumulativeWeight).toBe(15);
+      expect(item.cumulativeCost).toBe(36);
+      expect(item.cumulativeItemslots).toBe(2);
+    });
+  });
+
+  describe("migrateData", () => {
+    it("promotes a legacy details.description onto description", () => {
+      const item = new OseDataModelItem({ details: { description: "legacy" } });
+
+      expect(item.description).toBe("legacy");
+    });
+
+    it("leaves an existing description untouched", () => {
+      const item = new OseDataModelItem({ description: "current", details: { description: "legacy" } });
+
+      expect(item.description).toBe("current");
+    });
+  });
+
+  describe("isCoinsOrGems", () => {
+    it("is false when the item is not treasure", () => {
+      const item = new OseDataModelItem({ treasure: false, tags: [{ value: "gems" }] });
+
+      expect(item.isCoinsOrGems).toBe(false);
+    });
+
+    it("is true for treasure tagged as coins or gems", () => {
+      const item = new OseDataModelItem({ treasure: true, tags: [{ value: "gems" }] });
+
+      expect(item.isCoinsOrGems).toBe(true);
+    });
+
+    it("is true for treasure whose name ends in ' coins'", () => {
+      const item = new OseDataModelItem({ treasure: true }, { parent: { name: "Gold Coins" } });
+
+      expect(item.isCoinsOrGems).toBe(true);
+    });
+
+    it("is true for a treasure item named after a coin denomination", () => {
+      const item = new OseDataModelItem({ treasure: true }, { parent: { name: "GP" } });
+
+      expect(item.isCoinsOrGems).toBe(true);
+    });
+
+    it("is false for treasure with an unrelated name", () => {
+      const item = new OseDataModelItem({ treasure: true }, { parent: { name: "Ruby Idol" } });
+
+      expect(item.isCoinsOrGems).toBe(false);
+    });
+  });
+});

--- a/src/module/item/__tests__/data-model-spell.unit.test.ts
+++ b/src/module/item/__tests__/data-model-spell.unit.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import OseDataModelSpell from "../data-model-spell";
+
+describe("OseDataModelSpell", () => {
+  describe("schema defaults", () => {
+    it("initializes fields from defineSchema", () => {
+      const spell = new OseDataModelSpell();
+
+      expect(spell.save).toBe("");
+      expect(spell.lvl).toBeNull();
+      expect(spell.class).toBe("");
+      expect(spell.duration).toBe("");
+      expect(spell.range).toBe("");
+      expect(spell.roll).toBe("");
+      expect(spell.memorized).toBeNull();
+      expect(spell.cast).toBeNull();
+      expect(spell.description).toBe("");
+      expect(spell.tags).toEqual([]);
+    });
+  });
+
+  describe("manualTags", () => {
+    it("returns stored tags unchanged, with no label added", () => {
+      const spell = new OseDataModelSpell({ tags: [{ title: "title", value: "value" }] });
+
+      expect(spell.manualTags).toEqual([{ title: "title", value: "value" }]);
+    });
+
+    it("returns an empty array by default", () => {
+      expect(new OseDataModelSpell().manualTags).toEqual([]);
+    });
+
+    it("returns an empty array rather than null when tags is absent", () => {
+      const spell = new OseDataModelSpell();
+      spell.tags = undefined as never;
+
+      expect(spell.manualTags).toEqual([]);
+    });
+  });
+
+  describe("autoTags", () => {
+    it("always leads with class, range and duration, empty by default", () => {
+      expect(new OseDataModelSpell().autoTags).toEqual([{ label: "" }, { label: "" }, { label: "" }]);
+    });
+
+    it("surfaces class, range and duration in that order", () => {
+      const spell = new OseDataModelSpell({ class: "Magic-User", range: "60'", duration: "1 turn" });
+
+      expect(spell.autoTags).toEqual([{ label: "Magic-User" }, { label: "60'" }, { label: "1 turn" }]);
+    });
+
+    it("appends a save tag with a skull icon", () => {
+      const spell = new OseDataModelSpell({ save: "death" });
+
+      expect(spell.autoTags).toHaveLength(4);
+      expect(spell.autoTags[3]).toEqual({ label: CONFIG.OSE.saves_long.death, icon: "fa-skull" });
+    });
+
+    it("appends a roll tag with no roll target, unlike ability", () => {
+      const spell = new OseDataModelSpell({ roll: "1d20+1" });
+
+      expect(spell.autoTags).toHaveLength(4);
+      expect(spell.autoTags[3]).toEqual({ label: "OSE.items.Roll 1d20+1" });
+    });
+
+    it("orders the roll tag before the save tag", () => {
+      const spell = new OseDataModelSpell({ roll: "1d6", save: "death" });
+
+      expect(spell.autoTags).toHaveLength(5);
+      expect(spell.autoTags[3]?.label).toContain("1d6");
+      expect(spell.autoTags[4]).toEqual({ label: CONFIG.OSE.saves_long.death, icon: "fa-skull" });
+    });
+  });
+});

--- a/src/module/item/__tests__/data-model-weapon.unit.test.ts
+++ b/src/module/item/__tests__/data-model-weapon.unit.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest";
+import OseDataModelWeapon from "../data-model-weapon";
+
+const damageTag = { label: "", icon: "fa-tint" };
+
+describe("OseDataModelWeapon", () => {
+  describe("schema defaults", () => {
+    it("initializes fields from defineSchema", () => {
+      const weapon = new OseDataModelWeapon();
+
+      expect(weapon.melee).toBe(true);
+      expect(weapon.missile).toBe(false);
+      expect(weapon.slow).toBe(false);
+      expect(weapon.damage).toBe("");
+      expect(weapon.save).toBe("");
+      expect(weapon.pattern).toBe("");
+      expect(weapon.range).toEqual({ short: 0, medium: 0, long: 0 });
+      expect(weapon.counter).toEqual({ value: 0, max: 0 });
+      expect(weapon.tags).toEqual([]);
+      expect(weapon.equipped).toBe(false);
+      expect(weapon.itemslots).toBe(1);
+    });
+  });
+
+  describe("manualTags", () => {
+    it("returns an empty array by default", () => {
+      expect(new OseDataModelWeapon().manualTags).toEqual([]);
+    });
+
+    it("returns stored tags unchanged, without adding a label", () => {
+      const weapon = new OseDataModelWeapon({
+        tags: [{ title: "title", value: "value" }],
+      });
+
+      expect(weapon.manualTags).toEqual([{ title: "title", value: "value" }]);
+    });
+
+    it("omits tags whose value matches a known auto-tag", () => {
+      const weapon = new OseDataModelWeapon({
+        tags: [{ value: CONFIG.OSE.tags.blunt }],
+      });
+
+      expect(weapon.manualTags).toEqual([]);
+    });
+
+    it("returns null when tags is absent entirely", () => {
+      const weapon = new OseDataModelWeapon();
+      weapon.tags = undefined as never;
+
+      expect(weapon.manualTags).toBeNull();
+    });
+  });
+
+  describe("autoTags", () => {
+    it("leads with the damage tag and includes melee by default", () => {
+      const weapon = new OseDataModelWeapon();
+
+      expect(weapon.autoTags).toEqual([damageTag, CONFIG.OSE.auto_tags.melee]);
+    });
+
+    it("puts the damage formula in the leading tag", () => {
+      const weapon = new OseDataModelWeapon({ damage: "1d13" });
+
+      expect(weapon.autoTags[0]).toEqual({ label: "1d13", icon: "fa-tint" });
+    });
+
+    it("appends a range tag after the missile tag", () => {
+      const weapon = new OseDataModelWeapon({ melee: false, missile: true });
+
+      expect(weapon.autoTags).toEqual([
+        damageTag,
+        CONFIG.OSE.auto_tags.missile,
+        { label: "0/0/0", icon: "fa-bullseye" },
+      ]);
+    });
+
+    it("renders configured ranges as short/medium/long", () => {
+      const weapon = new OseDataModelWeapon({
+        melee: false,
+        missile: true,
+        range: { short: 30, medium: 60, long: 90 },
+      });
+
+      expect(weapon.autoTags[2]).toEqual({
+        label: "30/60/90",
+        icon: "fa-bullseye",
+      });
+    });
+
+    it("includes the slow tag after melee", () => {
+      const weapon = new OseDataModelWeapon({ slow: true });
+
+      expect(weapon.autoTags).toEqual([damageTag, CONFIG.OSE.auto_tags.melee, CONFIG.OSE.auto_tags.slow]);
+    });
+
+    it("appends a save tag last", () => {
+      const weapon = new OseDataModelWeapon({ save: "death" });
+
+      expect(weapon.autoTags[2]).toEqual({
+        label: CONFIG.OSE.saves_long.death,
+        icon: "fa-skull",
+      });
+    });
+  });
+
+  describe("qualities", () => {
+    it("returns only auto-tags carrying an image, titled by their label", () => {
+      const weapon = new OseDataModelWeapon();
+
+      expect(weapon.qualities).toEqual([
+        {
+          ...CONFIG.OSE.auto_tags.melee,
+          title: CONFIG.OSE.auto_tags.melee.label,
+        },
+      ]);
+    });
+
+    it("appends manual tags unchanged", () => {
+      const weapon = new OseDataModelWeapon({
+        tags: [{ value: "homebrew", label: "homebrew" }],
+      });
+
+      expect(weapon.qualities).toHaveLength(2);
+      expect(weapon.qualities[1]).toEqual({
+        value: "homebrew",
+        label: "homebrew",
+      });
+    });
+
+    it("includes an auto-tag that was set via a boolean flag", () => {
+      const weapon = new OseDataModelWeapon({ slow: true });
+
+      expect(weapon.qualities).toHaveLength(2);
+      expect(weapon.qualities[1]).toEqual({
+        ...CONFIG.OSE.auto_tags.slow,
+        title: CONFIG.OSE.auto_tags.slow.label,
+      });
+    });
+  });
+});

--- a/src/module/item/data-model-ability.ts
+++ b/src/module/item/data-model-ability.ts
@@ -1,9 +1,24 @@
 /**
  * @file The data model for Items of type Ability
  */
+import type { RollType, Save } from "../config";
 import OseTags from "../helpers-tags";
+import type { AbilityItemData, DisplayTag, ItemTag } from "./item-types";
 
-export default class OseDataModelAbility extends foundry.abstract.TypeDataModel {
+// fvtt-types cannot resolve this system's data models, so a precise Parent forces
+// casts here and full Item stubs in tests. Revisit if they are ever registered.
+// biome-ignore lint/suspicious/noExplicitAny: see above
+export default class OseDataModelAbility extends foundry.abstract.TypeDataModel<any, any> implements AbilityItemData {
+  declare save: Save | "";
+  declare pattern: string;
+  declare requirements: string;
+  declare roll: string;
+  declare rollType: RollType | "";
+  declare rollTarget: number | null;
+  declare blindroll: boolean;
+  declare description: string;
+  declare tags: ItemTag[];
+
   static defineSchema() {
     const { StringField, NumberField, BooleanField, ArrayField, ObjectField } = foundry.data.fields;
     return {
@@ -19,7 +34,7 @@ export default class OseDataModelAbility extends foundry.abstract.TypeDataModel 
     };
   }
 
-  get #rollTag() {
+  get #rollTag(): DisplayTag | null {
     if (!this.roll) return null;
 
     const rollLabel = game.i18n.localize("OSE.items.Roll");
@@ -39,7 +54,7 @@ export default class OseDataModelAbility extends foundry.abstract.TypeDataModel 
     };
   }
 
-  get #saveTag() {
+  get #saveTag(): DisplayTag | null {
     if (!this.save) return null;
 
     return {
@@ -48,11 +63,11 @@ export default class OseDataModelAbility extends foundry.abstract.TypeDataModel 
     };
   }
 
-  get manualTags() {
+  get manualTags(): ItemTag[] {
     return this.tags || [];
   }
 
-  get autoTags() {
+  get autoTags(): DisplayTag[] {
     return [
       ...(this.requirements?.split(",").map((req) => ({ label: req.trim() })) || []),
       this.#rollTag,

--- a/src/module/item/data-model-armor.ts
+++ b/src/module/item/data-model-armor.ts
@@ -1,13 +1,24 @@
 /**
  * @file The data model for Items of type Armor
  */
-export default class OseDataModelArmor extends foundry.abstract.TypeDataModel {
-  static ArmorTypes = {
-    unarmored: "OSE.armor.unarmored",
-    light: "OSE.armor.light",
-    heavy: "OSE.armor.heavy",
-    shield: "OSE.armor.shield",
-  };
+import { ARMOR_TYPES, type ArmorItemData, type ArmorType, type DisplayTag, type ItemTag } from "./item-types";
+
+// fvtt-types cannot resolve this system's data models, so a precise Parent forces
+// casts here and full Item stubs in tests. Revisit if they are ever registered.
+// biome-ignore lint/suspicious/noExplicitAny: see above
+export default class OseDataModelArmor extends foundry.abstract.TypeDataModel<any, any> implements ArmorItemData {
+  static ArmorTypes = ARMOR_TYPES;
+  declare type: ArmorType;
+  declare ac: { value: number };
+  declare aac: { value: number };
+  declare description: string;
+  declare tags: ItemTag[];
+  declare equipped: boolean;
+  declare cost: number;
+  declare containerId: string;
+  declare quantity: { value: number; max: number };
+  declare weight: number;
+  declare itemslots: number;
 
   static defineSchema() {
     const { SchemaField, StringField, NumberField, BooleanField, ArrayField, ObjectField } = foundry.data.fields;
@@ -40,25 +51,25 @@ export default class OseDataModelArmor extends foundry.abstract.TypeDataModel {
     };
   }
 
-  get manualTags() {
+  get manualTags(): ItemTag[] | null {
     if (!this.tags) return null;
 
-    const tagNames = new Set(Object.values(CONFIG.OSE.auto_tags).map(({ label }) => label));
+    const tagNames = new Set<string>(Object.values(CONFIG.OSE.auto_tags).map(({ label }) => label));
     return this.tags
       .filter(({ value }) => !tagNames.has(value))
-      .map(({ title, value }) => ({
-        title,
-        value,
-        label: value,
-      }));
+      .map(({ title, value }) => ({ title, value, label: value }));
   }
 
-  get autoTags() {
+  get autoTags(): DisplayTag[] {
     const tagNames = Object.values(CONFIG.OSE.auto_tags);
 
     const autoTags = this.tags.map(({ value }) => tagNames.find(({ label }) => value === label));
 
-    return [{ label: OseDataModelArmor.ArmorTypes[this.type], icon: "fa-tshirt" }, ...autoTags, ...this.manualTags]
+    return [
+      { label: OseDataModelArmor.ArmorTypes[this.type], icon: "fa-tshirt" },
+      ...autoTags,
+      ...(this.manualTags ?? []),
+    ]
       .flat()
       .filter((t) => !!t);
   }

--- a/src/module/item/data-model-container.ts
+++ b/src/module/item/data-model-container.ts
@@ -1,7 +1,25 @@
 /**
  * @file The data model for Items of type Container
  */
-export default class OseDataModelContainer extends foundry.abstract.TypeDataModel {
+import type { CarriedItem, ContainerItemData, DisplayTag, ItemTag } from "./item-types";
+
+export default class OseDataModelContainer
+  // system's data models, so a precise Parent forces casts here and full Item
+  // stubs in tests. Revisit if the models are registered with fvtt-types.
+  // biome-ignore lint/suspicious/noExplicitAny: fvtt-types cannot resolve this
+  extends foundry.abstract.TypeDataModel<any, any>
+  implements ContainerItemData
+{
+  declare itemIds: string[];
+  declare description: string;
+  declare tags: ItemTag[];
+  declare equipped: boolean;
+  declare cost: number;
+  declare containerId: string;
+  declare quantity: { value: number; max: number };
+  declare weight: number;
+  declare itemslots: number;
+
   static defineSchema() {
     const { SchemaField, StringField, NumberField, ArrayField, ObjectField, BooleanField } = foundry.data.fields;
     return {
@@ -20,33 +38,33 @@ export default class OseDataModelContainer extends foundry.abstract.TypeDataMode
     };
   }
 
-  get contents() {
+  get contents(): ContainerItemData["contents"] {
     if (!this.itemIds) return null;
     if (!this?.parent?.parent?.items) return null;
     const { id } = this.parent;
-    return this.parent.parent.items.filter(({ system: { containerId } }) => id === containerId);
+    return this.parent.parent.items.filter(({ system: { containerId } }: CarriedItem) => id === containerId);
   }
 
-  get totalWeight() {
+  get totalWeight(): number {
     if (!this.contents) return 0;
 
     return this.contents.reduce((acc, { system: { weight, quantity } }) => acc + weight * (quantity?.value || 1), 0);
   }
 
-  get manualTags() {
+  get manualTags(): ItemTag[] | null {
     if (!this.tags) return null;
 
-    const tagNames = new Set(Object.values(CONFIG.OSE.auto_tags).map(({ label }) => label));
+    const tagNames = new Set<string>(Object.values(CONFIG.OSE.auto_tags).map(({ label }) => label));
     return this.tags
       .filter(({ value }) => !tagNames.has(value))
       .map(({ title, value }) => ({ title, value, label: value }));
   }
 
-  get autoTags() {
+  get autoTags(): DisplayTag[] {
     const tagNames = Object.values(CONFIG.OSE.auto_tags);
 
     const autoTags = this.tags.map(({ value }) => tagNames.find(({ label }) => value === label));
 
-    return [...autoTags, ...this.manualTags].flat().filter((t) => !!t);
+    return [...autoTags, ...(this.manualTags ?? [])].flat().filter((t) => !!t);
   }
 }

--- a/src/module/item/data-model-item.ts
+++ b/src/module/item/data-model-item.ts
@@ -1,7 +1,23 @@
 /**
- * @file The data model for Items of type Ability
+ * @file The data model for Items of type Item (misc / treasure).
  */
-export default class OseDataModelItem extends foundry.abstract.TypeDataModel {
+
+import type { DisplayTag, ItemTag, LegacyItemSource, MiscItemData } from "./item-types";
+
+// fvtt-types cannot resolve this system's data models, so a precise Parent forces
+// casts here and full Item stubs in tests. Revisit if they are ever registered.
+// biome-ignore lint/suspicious/noExplicitAny: see above
+export default class OseDataModelItem extends foundry.abstract.TypeDataModel<any, any> implements MiscItemData {
+  declare treasure: boolean;
+  declare description: string;
+  declare tags: ItemTag[];
+  declare equipped: boolean;
+  declare cost: number;
+  declare containerId: string;
+  declare quantity: { value: number; max: number };
+  declare weight: number;
+  declare itemslots: number;
+
   static defineSchema() {
     const { SchemaField, StringField, NumberField, BooleanField, ArrayField, ObjectField } = foundry.data.fields;
     return {
@@ -32,26 +48,26 @@ export default class OseDataModelItem extends foundry.abstract.TypeDataModel {
     return Math.ceil(this.itemslots * this.quantity.value);
   }
 
-  static migrateData(source) {
+  static migrateData(source: LegacyItemSource) {
     if (source.details?.description && !source.description) source.description = source.details.description;
     return source;
   }
 
-  get manualTags() {
+  get manualTags(): ItemTag[] | null {
     if (!this.tags) return null;
 
-    const tagNames = new Set(Object.values(CONFIG.OSE.auto_tags).map(({ label }) => label));
+    const tagNames = new Set<string>(Object.values(CONFIG.OSE.auto_tags).map(({ label }) => label));
     return this.tags
       .filter(({ value }) => !tagNames.has(value))
       .map(({ title, value }) => ({ title, value, label: value }));
   }
 
-  get autoTags() {
+  get autoTags(): DisplayTag[] {
     const tagNames = Object.values(CONFIG.OSE.auto_tags);
 
     const autoTags = this.tags.map(({ value }) => tagNames.find(({ label }) => value === label));
 
-    return [...autoTags, ...this.manualTags].flat().filter((t) => !!t);
+    return [...autoTags, ...(this.manualTags ?? [])].flat().filter((t) => !!t);
   }
 
   get isCoinsOrGems() {

--- a/src/module/item/data-model-spell.ts
+++ b/src/module/item/data-model-spell.ts
@@ -1,9 +1,25 @@
 /**
  * @file The data model for Items of type Spell
  */
+import type { Save } from "../config";
 import OseTags from "../helpers-tags";
+import type { DisplayTag, ItemTag, SpellItemData } from "./item-types";
 
-export default class OseDataModelSpell extends foundry.abstract.TypeDataModel {
+// fvtt-types cannot resolve this system's data models, so a precise Parent forces
+// casts here and full Item stubs in tests. Revisit if they are ever registered.
+// biome-ignore lint/suspicious/noExplicitAny: see above
+export default class OseDataModelSpell extends foundry.abstract.TypeDataModel<any, any> implements SpellItemData {
+  declare save: Save | "";
+  declare lvl: number | null;
+  declare class: string;
+  declare duration: string;
+  declare range: string;
+  declare roll: string;
+  declare memorized: number | null;
+  declare cast: number | null;
+  declare description: string;
+  declare tags: ItemTag[];
+
   static defineSchema() {
     const { StringField, NumberField, ArrayField, ObjectField } = foundry.data.fields;
     return {
@@ -20,7 +36,7 @@ export default class OseDataModelSpell extends foundry.abstract.TypeDataModel {
     };
   }
 
-  get #rollTag() {
+  get #rollTag(): DisplayTag | null {
     if (!this.roll) return null;
 
     const rollLabel = game.i18n.localize("OSE.items.Roll");
@@ -35,7 +51,7 @@ export default class OseDataModelSpell extends foundry.abstract.TypeDataModel {
     };
   }
 
-  get #saveTag() {
+  get #saveTag(): DisplayTag | null {
     if (!this.save) return null;
 
     return {
@@ -44,11 +60,11 @@ export default class OseDataModelSpell extends foundry.abstract.TypeDataModel {
     };
   }
 
-  get manualTags() {
+  get manualTags(): ItemTag[] {
     return this.tags || [];
   }
 
-  get autoTags() {
+  get autoTags(): DisplayTag[] {
     return [
       { label: this.class ?? "" },
       { label: this.range ?? "" },

--- a/src/module/item/data-model-weapon.ts
+++ b/src/module/item/data-model-weapon.ts
@@ -1,7 +1,31 @@
 /**
  * @file The data model for Items of type Weapon
  */
-export default class OseDataModelWeapon extends foundry.abstract.TypeDataModel {
+import type { Save } from "../config";
+import type { DisplayTag, ItemTag, WeaponItemData } from "./item-types";
+
+// fvtt-types cannot resolve this system's data models, so a precise Parent forces
+// casts here and full Item stubs in tests. Revisit if they are ever registered.
+// biome-ignore lint/suspicious/noExplicitAny: see above
+export default class OseDataModelWeapon extends foundry.abstract.TypeDataModel<any, any> implements WeaponItemData {
+  declare damage: string;
+  declare save: Save | "";
+  declare range: { short: number; medium: number; long: number };
+  declare bonus: number | null;
+  declare pattern: string;
+  declare missile: boolean;
+  declare melee: boolean;
+  declare slow: boolean;
+  declare counter: { value: number; max: number };
+  declare description: string;
+  declare tags: ItemTag[];
+  declare equipped: boolean;
+  declare cost: number;
+  declare containerId: string;
+  declare quantity: { value: number; max: number };
+  declare weight: number;
+  declare itemslots: number;
+
   static defineSchema() {
     const { SchemaField, StringField, NumberField, BooleanField, ArrayField, ObjectField } = foundry.data.fields;
     return {
@@ -35,7 +59,7 @@ export default class OseDataModelWeapon extends foundry.abstract.TypeDataModel {
     };
   }
 
-  get #missileTag() {
+  get #missileTag(): DisplayTag[] | null {
     if (!this.missile) return null;
     return [
       CONFIG.OSE.auto_tags.missile,
@@ -46,17 +70,17 @@ export default class OseDataModelWeapon extends foundry.abstract.TypeDataModel {
     ];
   }
 
-  get #meleeTag() {
+  get #meleeTag(): DisplayTag | null {
     if (!this.melee) return null;
     return CONFIG.OSE.auto_tags.melee;
   }
 
-  get #slowTag() {
+  get #slowTag(): DisplayTag | null {
     if (!this.slow) return null;
     return CONFIG.OSE.auto_tags.slow;
   }
 
-  get #saveTag() {
+  get #saveTag(): DisplayTag | null {
     if (!this.save) return null;
 
     return {
@@ -65,10 +89,10 @@ export default class OseDataModelWeapon extends foundry.abstract.TypeDataModel {
     };
   }
 
-  get manualTags() {
+  get manualTags(): ItemTag[] | null {
     if (!this.tags) return null;
 
-    const tagNames = new Set(Object.values(CONFIG.OSE.auto_tags).map(({ label }) => label));
+    const tagNames = new Set<string>(Object.values(CONFIG.OSE.auto_tags).map(({ label }) => label));
     return this.tags.filter(({ value }) => !tagNames.has(value));
   }
 
@@ -77,7 +101,7 @@ export default class OseDataModelWeapon extends foundry.abstract.TypeDataModel {
    *
    * @returns {Array} - An array of qualities that display in the "Qualities" column on an Actor's Inventory sheet
    */
-  get qualities() {
+  get qualities(): DisplayTag[] {
     return [
       ...this.autoTags
         .filter((t) => !!t.image)
@@ -85,11 +109,11 @@ export default class OseDataModelWeapon extends foundry.abstract.TypeDataModel {
           ...t,
           title: t.label,
         })),
-      ...this.manualTags,
+      ...(this.manualTags ?? []),
     ];
   }
 
-  get autoTags() {
+  get autoTags(): DisplayTag[] {
     const tagNames = Object.values(CONFIG.OSE.auto_tags);
 
     const autoTags = this.tags.map(({ value }) => tagNames.find(({ label }) => value === label));

--- a/src/module/item/data-models.ts
+++ b/src/module/item/data-models.ts
@@ -1,0 +1,31 @@
+/**
+ * @file The Item data models this system registers, and their declaration to
+ * fvtt-types.
+ *
+ * `ose.js` assigns `CONFIG.Item.dataModels` from this object, and the
+ * `DataModelConfig` merge below derives from the same value — so an item type
+ * cannot be registered at runtime without also being typed, or vice versa.
+ *
+ * Without this, `item.system` resolves to `UnknownSystem` everywhere.
+ */
+import OseDataModelAbility from "./data-model-ability";
+import OseDataModelArmor from "./data-model-armor";
+import OseDataModelContainer from "./data-model-container";
+import OseDataModelItem from "./data-model-item";
+import OseDataModelSpell from "./data-model-spell";
+import OseDataModelWeapon from "./data-model-weapon";
+
+export const ITEM_DATA_MODELS = {
+  ability: OseDataModelAbility,
+  armor: OseDataModelArmor,
+  container: OseDataModelContainer,
+  item: OseDataModelItem,
+  spell: OseDataModelSpell,
+  weapon: OseDataModelWeapon,
+} as const;
+
+declare global {
+  interface DataModelConfig {
+    Item: typeof ITEM_DATA_MODELS;
+  }
+}

--- a/src/module/item/entity.ts
+++ b/src/module/item/entity.ts
@@ -4,13 +4,36 @@
 import OSE from "../config";
 import OseDice from "../helpers-dice";
 import { getRollMode } from "../helpers-message-mode";
+import type { ITEM_DATA_MODELS } from "./data-models";
+import type { DisplayTag, ItemTag } from "./item-types";
+
+/** The Item subtypes this system registers. */
+type OseItemType = keyof typeof ITEM_DATA_MODELS;
+
+/**
+ * The union of every registered item's system data.
+ *
+ * Methods below switch on `this.type` before reading subtype-specific fields,
+ * but TypeScript cannot narrow `this.system` from `this.type` — `this` is not a
+ * discriminated union — so those reads assert the shape the switch guarantees.
+ */
+// biome-ignore lint/suspicious/noExplicitAny: the union is read field-by-field after a type switch
+type AnyItemSystem = Item["system"] & Record<string, any>;
+
+/**
+ * The owning Actor, as this file needs it. The actor entity is still JavaScript
+ * and its data models are not registered with fvtt-types, so members like
+ * `targetAttack` and `rollSave` are not yet visible on Foundry's `Actor`.
+ */
+// biome-ignore lint/suspicious/noExplicitAny: until the actor entity is TypeScript
+type OwningActor = Actor & Record<string, any>;
 
 /**
  * Override and extend the basic :class:`Item` implementation
  */
 export default class OseItem extends Item {
   // Replacing default image */
-  static get defaultIcons() {
+  static get defaultIcons(): Record<OseItemType, string> {
     return {
       spell: `${OSE.assetsPath}/default/spell.png`,
       ability: `${OSE.assetsPath}/default/ability.png`,
@@ -21,20 +44,27 @@ export default class OseItem extends Item {
     };
   }
 
-  static async create(data, context = {}) {
+  // Narrowing these to Item.CreateData / CreateOperation breaks static-side
+  // compatibility with Item.create's generic overloads (TS2417).
+  // biome-ignore lint/suspicious/noExplicitAny: see above
+  static async create(data: any, context: any = {}) {
     if (data.img === undefined) {
-      data.img = OseItem.defaultIcons[data.type];
+      data.img = OseItem.defaultIcons[data.type as OseItemType];
     }
     return Item.create(data, context);
   }
 
-  static migrateData(source) {
+  static migrateData(source: {
+    img?: string;
+    type?: string;
+    system?: { itemslots?: number; tags?: ItemTag[]; type?: string };
+  }) {
     if (source?.img === "" && source.type) {
-      source.img = OseItem.defaultIcons[source.type];
+      source.img = OseItem.defaultIcons[source.type as OseItemType];
     }
     if (source?.system?.itemslots === undefined) {
-      if ((source?.system?.tags ?? []).some((tag) => tag.value === "Two-handed") && source?.type === "weapon")
-        source.system.itemslots = 2;
+      if ((source?.system?.tags ?? []).some((tag: ItemTag) => tag.value === "Two-handed") && source?.type === "weapon")
+        (source.system as { itemslots?: number }).itemslots = 2;
       if (source?.system?.type === "heavy" && source.type === "armor") source.system.itemslots = 2;
     }
 
@@ -45,33 +75,35 @@ export default class OseItem extends Item {
     super.prepareData();
   }
 
-  async prepareDerivedData() {
+  async prepareDerivedData(): Promise<void> {
     // Rich text description
-    this.system.enrichedDescription = await foundry.applications.ux.TextEditor.implementation.enrichHTML(
-      this.system.description,
-      { async: true },
-    );
+    (this.system as AnyItemSystem).enrichedDescription =
+      // `async` was removed from EnrichmentOptions in v13; kept so the call is
+      // byte-identical to the JavaScript this replaces.
+      await foundry.applications.ux.TextEditor.implementation.enrichHTML((this.system as AnyItemSystem).description, {
+        async: true,
+      } as never);
   }
 
-  static chatListeners(html) {
+  static chatListeners(html: HTMLElement) {
     // Use event delegation for buttons
-    html.addEventListener("click", (event) => {
-      const button = event.target.closest(".card-buttons button");
+    html.addEventListener("click", (event: MouseEvent) => {
+      const button = (event.target as HTMLElement).closest(".card-buttons button");
       if (button) {
         OseItem._onChatCardAction(event);
       }
 
-      const itemName = event.target.closest(".item-name");
+      const itemName = (event.target as HTMLElement).closest(".item-name");
       if (itemName) {
         OseItem._onChatCardToggleContent(event);
       }
     });
   }
 
-  async getChatData(_htmlOptions) {
+  async getChatData(_htmlOptions?: unknown) {
     const itemType = this.type;
 
-    const itemData = this.system;
+    const itemData = this.system as AnyItemSystem;
 
     // Item properties
     const props = [];
@@ -93,15 +125,15 @@ export default class OseItem extends Item {
     return itemData;
   }
 
-  rollWeapon(options = {}) {
-    const isNPC = this.actor.type !== "character";
-    const _targets = 5;
+  rollWeapon(options: Record<string, unknown> = {}) {
+    const actor = this.actor as OwningActor;
+    const isNPC = (actor.type as string) !== "character";
     const itemData = this.system;
 
     let type = isNPC ? "attack" : "melee";
     const rollData = {
       item: this._source,
-      actor: this.actor,
+      actor: this.actor as OwningActor,
       roll: {
         save: itemData.save,
         target: null,
@@ -120,7 +152,7 @@ export default class OseItem extends Item {
             label: game.i18n.localize("OSE.Melee"),
             default: true,
             callback: () => {
-              this.actor.targetAttack(rollData, "melee", options);
+              actor.targetAttack(rollData, "melee", options);
             },
           },
           {
@@ -128,7 +160,7 @@ export default class OseItem extends Item {
             icon: "fas fa-bullseye",
             label: game.i18n.localize("OSE.Missile"),
             callback: () => {
-              this.actor.targetAttack(rollData, "missile", options);
+              actor.targetAttack(rollData, "missile", options);
             },
           },
         ],
@@ -138,11 +170,11 @@ export default class OseItem extends Item {
     if (itemData.missile && !isNPC) {
       type = "missile";
     }
-    this.actor.targetAttack(rollData, type, options);
+    actor.targetAttack(rollData, type, options);
     return true;
   }
 
-  async rollFormula(options = {}) {
+  async rollFormula(options: { event?: Event } = {}) {
     const itemData = this.system;
 
     if (!itemData.roll) {
@@ -154,8 +186,8 @@ export default class OseItem extends Item {
 
     const type = itemData.rollType;
 
-    const rollData = {
-      actor: this.actor,
+    const rollData: Record<string, unknown> = {
+      actor: this.actor as OwningActor,
       item: this._source,
       description: null,
       save: itemData.save,
@@ -177,10 +209,11 @@ export default class OseItem extends Item {
       parts: rollParts,
       data: rollData,
       skipDialog: true,
-      speaker: ChatMessage.getSpeaker({ actor: this }),
+      // biome-ignore lint/suspicious/noExplicitAny: getSpeaker expects an Actor; this passes the Item, as the original did
+      speaker: ChatMessage.getSpeaker({ actor: this as any }),
       flavor: game.i18n.format("OSE.roll.formula", { label }),
       title: game.i18n.format("OSE.roll.formula", { label }),
-    });
+    } as never);
   }
 
   async spendSpell() {
@@ -189,7 +222,7 @@ export default class OseItem extends Item {
     const itemData = this.system;
     await this.update({
       system: {
-        cast: itemData.cast - 1,
+        cast: (itemData.cast ?? 0) - 1,
       },
     });
 
@@ -200,29 +233,31 @@ export default class OseItem extends Item {
     }
   }
 
-  _getRollTag(data) {
+  _getRollTag(data: AnyItemSystem): DisplayTag | undefined {
     if (data.roll) {
       const roll = `${data.roll}${
-        data.rollTarget ? CONFIG.OSE.roll_type[data.rollType] : ""
+        data.rollTarget ? CONFIG.OSE.roll_type[data.rollType as keyof typeof CONFIG.OSE.roll_type] : ""
       }${data.rollTarget ? data.rollTarget : ""}`;
       return {
         label: `${game.i18n.localize("OSE.items.Roll")} ${roll}`,
       };
     }
+    return undefined;
   }
 
-  _getSaveTag(data) {
+  _getSaveTag(data: AnyItemSystem): DisplayTag | undefined {
     if (data.save) {
       return {
         label: CONFIG.OSE.saves_long[data.save],
         icon: "fa-skull",
       };
     }
+    return undefined;
   }
 
-  getAutoTagList() {
-    const tagList = [];
-    const data = this.system;
+  getAutoTagList(): DisplayTag[] {
+    const tagList: DisplayTag[] = [];
+    const data = this.system as AnyItemSystem;
     const itemType = this.type;
 
     switch (itemType) {
@@ -232,7 +267,7 @@ export default class OseItem extends Item {
       }
 
       case "weapon": {
-        tagList.push({ label: data.damage, icon: "fa-tint" });
+        tagList.push({ label: data.damage as string, icon: "fa-tint" });
         if (data.missile) {
           tagList.push({
             label: `${data.range.short}/${data.range.medium}/${data.range.long}`,
@@ -248,17 +283,17 @@ export default class OseItem extends Item {
       }
 
       case "armor": {
-        tagList.push({ label: CONFIG.OSE.armor[data.type], icon: "fa-tshirt" });
+        tagList.push({ label: CONFIG.OSE.armor[data.type as keyof typeof CONFIG.OSE.armor], icon: "fa-tshirt" });
         break;
       }
 
       case "spell": {
-        tagList.push({ label: data.class }, { label: data.range }, { label: data.duration });
+        tagList.push({ label: data.class }, { label: data.range as string }, { label: data.duration });
         break;
       }
 
       case "ability": {
-        const reqs = data.requirements.split(",");
+        const reqs = (data.requirements ?? "").split(",");
         for (const req of reqs) {
           tagList.push({ label: req });
         }
@@ -288,13 +323,13 @@ export default class OseItem extends Item {
    * @param {string[]} values - The values of the tags to add.
    * @returns {Promise<OseItem|undefined>>} - The updated Document instance, or undefined if not updated
    */
-  async pushManualTag(values) {
-    const data = this?.system;
-    let update = [];
+  async pushManualTag(values: string[]) {
+    const data = this?.system as AnyItemSystem;
+    let update: ItemTag[] = [];
     if (data.tags) {
       update = data.tags;
     }
-    const newData = {};
+    const newData: Record<string, unknown> = {};
     const regExp = /\(([^)]+)\)/;
     values.forEach((val) => {
       // Catch infos in brackets
@@ -302,7 +337,7 @@ export default class OseItem extends Item {
       let title = "";
       let trimmedVal = "";
       if (matches) {
-        title = matches[1];
+        title = matches[1] ?? "";
         trimmedVal = val.slice(0, Math.max(0, matches.index)).trim();
       } else {
         trimmedVal = val.trim();
@@ -335,7 +370,7 @@ export default class OseItem extends Item {
         });
       }
 
-      if (trimmedVal === "Two-handed" && this.type === "weapon") {
+      if (trimmedVal === "Two-handed" && (this.type as string) === "weapon") {
         newData.itemslots = 2;
       }
     });
@@ -349,21 +384,21 @@ export default class OseItem extends Item {
    * @param {string} value - The value of the tag to remove.
    * @returns {Promise<OseItem|undefined>} - The updated Document instance, or undefined if not updated
    */
-  popManualTag(value) {
-    const itemData = this.system;
+  popManualTag(value: string) {
+    const itemData = this.system as AnyItemSystem;
 
     const { tags } = itemData;
     if (!tags) return;
 
-    const update = tags.filter((el) => el.value.toLowerCase() !== value.toLowerCase());
+    const update = tags.filter((el: ItemTag) => el.value.toLowerCase() !== value.toLowerCase());
     const newData = {
       tags: update,
     };
     return this.update({ system: newData });
   }
 
-  roll(options = {}) {
-    const itemData = this.system;
+  roll(options: Record<string, unknown> = {}) {
+    const itemData = this.system as AnyItemSystem;
     switch (this.type) {
       case "weapon": {
         this.rollWeapon(options);
@@ -371,7 +406,7 @@ export default class OseItem extends Item {
       }
 
       case "spell": {
-        this.spendSpell(options);
+        this.spendSpell();
         break;
       }
 
@@ -387,7 +422,9 @@ export default class OseItem extends Item {
       case "item":
       case "armor": {
         this.show();
+        break;
       }
+      // No default
     }
   }
 
@@ -396,39 +433,40 @@ export default class OseItem extends Item {
    *
    * @returns {Promise}
    */
-  async show() {
+  async show(_options: Record<string, unknown> = {}) {
     const itemType = this.type;
     // Basic template rendering data
-    const token = this.actor?.token;
-    const templateData = {
-      actor: this.actor,
-      tokenId: token ? `${token.parent.id}.${token.id}` : null,
+    const token = (this.actor as OwningActor | null)?.token;
+    const templateData: Record<string, unknown> = {
+      actor: this.actor as OwningActor,
+      tokenId: token ? `${token.parent?.id}.${token.id}` : null,
       item: this._source,
-      itemId: this._source._id,
+      itemId: (this._source as { _id?: string })._id,
       data: await this.getChatData(),
-      labels: this.labels,
-      isHealing: this.isHealing,
-      hasDamage: this.hasDamage,
+      labels: (this as unknown as Record<string, unknown>).labels,
+      isHealing: (this as unknown as Record<string, unknown>).isHealing,
+      hasDamage: (this as unknown as Record<string, unknown>).hasDamage,
       isSpell: itemType === "spell",
-      hasSave: this.hasSave,
+      hasSave: (this as unknown as Record<string, unknown>).hasSave,
       config: CONFIG.OSE,
     };
-    templateData.rollFormula = new Roll(templateData.data.roll, templateData).formula;
-    templateData.data.properties = this.system.autoTags;
+    const chatItemData = templateData.data as AnyItemSystem;
+    templateData.rollFormula = new Roll(chatItemData.roll ?? "", templateData).formula;
+    chatItemData.properties = this.system.autoTags;
 
     // Render the chat card template
     const template = `${OSE.systemPath()}/templates/chat/item-card.html`;
     const html = await foundry.applications.handlebars.renderTemplate(template, templateData);
 
     // Basic chat message data
-    const chatData = {
+    const chatData: Record<string, unknown> = {
       user: game.user.id,
       style: CONST.CHAT_MESSAGE_STYLES.OTHER,
       content: html,
       speaker: {
-        actor: this.actor?.id,
-        token: this.actor?.token,
-        alias: this.actor?.name,
+        actor: (this.actor as OwningActor | null)?.id,
+        token: (this.actor as OwningActor | null)?.token,
+        alias: (this.actor as OwningActor | null)?.name,
       },
     };
 
@@ -439,7 +477,7 @@ export default class OseItem extends Item {
     if (rollMode === "blindroll") chatData.blind = true;
 
     // Create the chat message
-    return ChatMessage.create(chatData);
+    return ChatMessage.create(chatData as never);
   }
 
   /**
@@ -448,11 +486,11 @@ export default class OseItem extends Item {
    * @param {Event} event - The originating click event
    * @private
    */
-  static _onChatCardToggleContent(event) {
+  static _onChatCardToggleContent(event: Event) {
     event.preventDefault();
-    const header = event.target.closest(".item-name");
-    const card = header.closest(".chat-card");
-    const content = card.querySelector(".card-content");
+    const header = (event.target as HTMLElement).closest(".item-name");
+    const card = header?.closest(".chat-card") as HTMLElement | null;
+    const content = card?.querySelector(".card-content") as HTMLElement;
     if (content.style.display === "none") {
       $(content).slideDown(200);
     } else {
@@ -460,38 +498,41 @@ export default class OseItem extends Item {
     }
   }
 
-  static async _onChatCardAction(event) {
+  static async _onChatCardAction(event: Event): Promise<unknown> {
     event.preventDefault();
 
     // Extract card data
-    const button = event.target.closest(".card-buttons button");
+    const button = (event.target as HTMLElement).closest(".card-buttons button") as HTMLButtonElement;
     button.disabled = true;
-    const card = button.closest(".chat-card");
-    const { messageId } = card.closest(".message").dataset;
-    const message = game.messages.get(messageId);
+    const card = button.closest(".chat-card") as HTMLElement;
+    const { messageId } = (card.closest(".message") as HTMLElement).dataset;
+    const message = game.messages.get(messageId as string);
     const { action } = button.dataset;
 
     // Validate permission to proceed with the roll
     const isTargetted = action === "save";
-    if (!(isTargetted || game.user.isGM || message.isAuthor)) return;
+    if (!(isTargetted || game.user.isGM || message?.isAuthor)) return;
 
     // Get the Actor from a synthetic Token
     const actor = OseItem._getChatCardActor(card);
     if (!actor) return;
 
     // Get the Item
-    const item = actor.items.get(card.dataset.itemId);
+    // Widened because the "damage" branch below calls item.rollDamage, which is
+    // defined on the Actor, not the Item — preserved from the JavaScript.
+    // biome-ignore lint/suspicious/noExplicitAny: see above
+    const item = actor.items.get(card.dataset.itemId as string) as (OseItem & Record<string, any>) | undefined;
     if (!item) {
       return ui.notifications.error(
         game.i18n.format("OSE.error.itemNoLongerExistsOnActor", {
           actorName: actor.name,
-          itemId: card.dataset.itemId,
+          itemId: card.dataset.itemId ?? "",
         }),
       );
     }
 
     // Get card targets
-    let targets = [];
+    let targets: OwningActor[] = [];
     if (isTargetted) {
       targets = OseItem._getChatCardTargets(card);
     }
@@ -525,30 +566,31 @@ export default class OseItem extends Item {
 
     // Re-enable the button
     button.disabled = false;
+    return undefined;
   }
 
-  static _getChatCardActor(card) {
+  static _getChatCardActor(card: HTMLElement): OwningActor | null {
     // Case 1 - a synthetic actor from a Token
     const tokenKey = card.dataset.tokenId;
     if (tokenKey) {
       const [sceneId, tokenId] = tokenKey.split(".");
-      const scene = game.scenes.get(sceneId);
+      const scene = game.scenes.get(sceneId as string);
       if (!scene) return null;
-      const tokenData = scene.getEmbeddedDocument("Token", tokenId);
+      const tokenData = scene.getEmbeddedDocument("Token", tokenId as string, {});
       if (!tokenData) return null;
-      const token = new Token(tokenData);
+      const token = new (Token as unknown as new (data: unknown) => { actor: OwningActor })(tokenData);
       return token.actor;
     }
 
     // Case 2 - use Actor ID directory
     const { actorId } = card.dataset;
-    return game.actors.get(actorId) || null;
+    return game.actors.get(actorId as string) || null;
   }
 
-  static _getChatCardTargets(_card) {
+  static _getChatCardTargets(_card: HTMLElement) {
     const { character } = game.user;
-    const { controlled } = canvas.tokens;
-    const targets = controlled.filter((t) => t.actor).map((t) => t.actor);
+    const { controlled } = canvas.tokens as unknown as { controlled: { actor?: OwningActor }[] };
+    const targets = controlled.flatMap((t) => (t.actor ? [t.actor] : []));
     if (character && controlled.length === 0) targets.push(character);
     return targets;
   }

--- a/src/module/item/item-types.ts
+++ b/src/module/item/item-types.ts
@@ -1,0 +1,154 @@
+/**
+ * @file The public type surface for Item data models.
+ *
+ * Kept apart from the data model classes themselves: a class module carries
+ * inference obligations (notably `defineSchema`'s return type, which cannot be
+ * named portably) that break the declaration build behind
+ * `@ose-foundry-core/types`. Interfaces here have none.
+ */
+import type { InventoryItemTagValue, RollType, Save } from "../config";
+
+/**
+ * A tag as stored on an Item's `tags` schema field.
+ *
+ * `pushManualTag` (item/entity.js) writes all three, deriving `title` from a
+ * trailing `(parenthetical)` and defaulting it to the value otherwise. `title`
+ * and `label` stay optional because tags predating that writer, and those built
+ * directly in tests, carry only a value.
+ */
+export interface ItemTag {
+  title?: string;
+  value: InventoryItemTagValue | (string & {});
+  label?: string;
+}
+
+/**
+ * A tag ready for rendering, from CONFIG.OSE.auto_tags or echoed from a stored
+ * tag. `label` is optional because the rendering partial guards on it
+ * (`{{#if tag.label}}` in item-auto-tags-partial.html).
+ */
+export interface DisplayTag {
+  label?: string;
+  value?: InventoryItemTagValue | (string & {});
+  title?: string;
+  icon?: string;
+  image?: string;
+}
+
+/**
+ * The fields every inventory item carries, regardless of type. Ability and
+ * spell items deliberately sit outside this: they have no physical presence,
+ * and their `manualTags` returns stored tags unchanged rather than the
+ * filtered, labelled tags below.
+ */
+export interface PhysicalItemData {
+  description: string;
+  tags: ItemTag[];
+  equipped: boolean;
+  cost: number;
+  containerId: string;
+  quantity: { value: number; max: number };
+  weight: number;
+  itemslots: number;
+
+  readonly manualTags: ItemTag[] | null;
+  readonly autoTags: DisplayTag[];
+}
+
+export interface MiscItemData extends PhysicalItemData {
+  treasure: boolean;
+
+  readonly cumulativeWeight: number;
+  readonly cumulativeCost: number;
+  readonly cumulativeItemslots: number;
+  readonly isCoinsOrGems: boolean;
+}
+
+/** The armour categories an armor Item can belong to, as localization keys. */
+export const ARMOR_TYPES = {
+  unarmored: "OSE.armor.unarmored",
+  light: "OSE.armor.light",
+  heavy: "OSE.armor.heavy",
+  shield: "OSE.armor.shield",
+} as const;
+
+/** Which armour category an item falls into. */
+export type ArmorType = keyof typeof ARMOR_TYPES;
+
+/** The type and AC/AAC value of an armor item */
+export interface ArmorItemData extends PhysicalItemData {
+  type: ArmorType;
+  ac: { value: number };
+  aac: { value: number };
+}
+
+export interface WeaponItemData extends PhysicalItemData {
+  damage: string;
+  save: Save | "";
+  range: { short: number; medium: number; long: number };
+  bonus: number | null;
+  pattern: string;
+  missile: boolean;
+  melee: boolean;
+  slow: boolean;
+  counter: { value: number; max: number };
+
+  /** Auto-tags carrying an image, plus manual tags — the inventory grid's "Qualities" column. */
+  readonly qualities: DisplayTag[];
+}
+
+/** The subset of an Item a container reads off its Actor's inventory. */
+export interface CarriedItem {
+  system: {
+    containerId: string;
+    weight: number;
+    quantity?: { value: number };
+  };
+}
+
+export interface ContainerItemData extends PhysicalItemData {
+  itemIds: string[];
+
+  /** Items on the containing Actor whose `containerId` points at this container. */
+  readonly contents: CarriedItem[] | null;
+  readonly totalWeight: number;
+}
+
+/** An item's raw source during migration, before the schema has cleaned it. */
+export type LegacyItemSource = Record<string, unknown> & {
+  description?: string;
+  details?: { description?: string };
+};
+
+/**
+ * Fields common to Items with no physical presence — abilities and spells.
+ * These sit outside {@link PhysicalItemData}: they are never equipped, carried
+ * or counted against encumbrance, and their `manualTags` returns stored tags
+ * unchanged rather than the filtered, labelled set physical items produce.
+ */
+export interface NonPhysicalItemData {
+  description: string;
+  tags: ItemTag[];
+  save: Save | "";
+  roll: string;
+
+  readonly manualTags: ItemTag[];
+  readonly autoTags: DisplayTag[];
+}
+
+export interface AbilityItemData extends NonPhysicalItemData {
+  pattern: string;
+  requirements: string;
+  rollType: RollType | "";
+  rollTarget: number | null;
+  blindroll: boolean;
+}
+
+export interface SpellItemData extends NonPhysicalItemData {
+  lvl: number | null;
+  class: string;
+  duration: string;
+  range: string;
+  memorized: number | null;
+  cast: number | null;
+}

--- a/src/ose.js
+++ b/src/ose.js
@@ -18,12 +18,7 @@ import handlebarsHelpers from "./module/helpers-handlebars";
 import * as macros from "./module/helpers-macros";
 import * as party from "./module/helpers-party";
 import * as treasure from "./module/helpers-treasure";
-import OseDataModelAbility from "./module/item/data-model-ability";
-import OseDataModelArmor from "./module/item/data-model-armor";
-import OseDataModelContainer from "./module/item/data-model-container";
-import OseDataModelItem from "./module/item/data-model-item";
-import OseDataModelSpell from "./module/item/data-model-spell";
-import OseDataModelWeapon from "./module/item/data-model-weapon";
+import { ITEM_DATA_MODELS } from "./module/item/data-models";
 import OseItem from "./module/item/entity";
 import OseItemSheet from "./module/item/item-sheet";
 import OsePartySheet from "./module/party/party-sheet";
@@ -40,7 +35,6 @@ import "./e2e";
 
 Hooks.once("init", async () => {
   CONFIG.OSE = OSE;
-
   // Give modules a chance to add encumbrance schemes
   // They can do so by adding their encumbrance schemes
   // to CONFIG.OSE.encumbranceOptions
@@ -89,14 +83,7 @@ Hooks.once("init", async () => {
     character: OseDataModelCharacter,
     monster: OseDataModelMonster,
   };
-  CONFIG.Item.dataModels = {
-    weapon: OseDataModelWeapon,
-    armor: OseDataModelArmor,
-    item: OseDataModelItem,
-    spell: OseDataModelSpell,
-    ability: OseDataModelAbility,
-    container: OseDataModelContainer,
-  };
+  CONFIG.Item.dataModels = ITEM_DATA_MODELS;
 
   // Register sheet application classes
   foundry.documents.collections.Actors.unregisterSheet("core", foundry.appv1.sheets.ActorSheet);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -35,5 +35,18 @@ export type {
   RollType,
   Save,
 } from "../module/config";
-
+export type {
+  AbilityItemData,
+  ArmorItemData,
+  ArmorType,
+  CarriedItem,
+  ContainerItemData,
+  DisplayTag,
+  ItemTag,
+  MiscItemData,
+  NonPhysicalItemData,
+  PhysicalItemData,
+  SpellItemData,
+  WeaponItemData,
+} from "../module/item/item-types";
 export type { ClassicClassName, OseClass } from "./classes";

--- a/test/foundry-stub.ts
+++ b/test/foundry-stub.ts
@@ -1,0 +1,150 @@
+/**
+ * @file Minimal Foundry globals for running data-model logic under Vitest.
+ *
+ * Mirrors only what the item data models touch: the `TypeDataModel` base, the
+ * schema field classes used by `defineSchema()`, `CONFIG.OSE`, and
+ * `game.i18n.localize`. Anything beyond that is deliberately absent — a test
+ * that needs more Foundry than this belongs in the Quench suite.
+ */
+import { OSE } from "../src/module/config";
+
+interface FieldOptions {
+  initial?: unknown;
+}
+
+class DataField {
+  options: FieldOptions;
+
+  constructor(options: FieldOptions = {}) {
+    this.options = options ?? {};
+  }
+
+  getInitialValue(): unknown {
+    return this.options.initial;
+  }
+}
+
+class StringField extends DataField {
+  getInitialValue() {
+    return this.options.initial ?? "";
+  }
+}
+
+class NumberField extends DataField {
+  getInitialValue() {
+    return this.options.initial ?? null;
+  }
+}
+
+class BooleanField extends DataField {
+  getInitialValue() {
+    return this.options.initial ?? false;
+  }
+}
+
+class ArrayField extends DataField {
+  constructor(
+    readonly element: DataField,
+    options: FieldOptions = {},
+  ) {
+    super(options);
+  }
+
+  getInitialValue() {
+    return this.options.initial ?? [];
+  }
+}
+
+class ObjectField extends DataField {
+  getInitialValue() {
+    return this.options.initial ?? {};
+  }
+}
+
+class SchemaField extends DataField {
+  constructor(
+    readonly fields: Record<string, DataField>,
+    options: FieldOptions = {},
+  ) {
+    super(options);
+  }
+
+  getInitialValue() {
+    return Object.fromEntries(Object.entries(this.fields).map(([key, field]) => [key, field.getInitialValue()]));
+  }
+}
+
+/**
+ * Stands in for `foundry.abstract.TypeDataModel`. Foundry runs `migrateData`
+ * over the source before initializing fields, so this does too — otherwise
+ * migration logic would be untestable here.
+ */
+class TypeDataModel {
+  parent: unknown;
+
+  /** The cleaned source, as Foundry exposes it. Tag helpers read roll data off this. */
+  _source: Record<string, unknown> = {};
+
+  constructor(source: Record<string, unknown> = {}, options: { parent?: unknown } = {}) {
+    const ctor = new.target as unknown as {
+      defineSchema(): Record<string, DataField>;
+      migrateData?(source: Record<string, unknown>): Record<string, unknown>;
+    };
+
+    this.parent = options.parent;
+
+    const migrated = ctor.migrateData ? ctor.migrateData({ ...source }) : source;
+    const schema = ctor.defineSchema();
+
+    for (const [key, field] of Object.entries(schema)) {
+      const provided = migrated[key];
+      const value = provided === undefined ? field.getInitialValue() : provided;
+      this._source[key] = value;
+      Object.defineProperty(this, key, {
+        value,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      });
+    }
+  }
+
+  /** Merges changes into the source and the initialized fields, as Foundry does. */
+  updateSource(changes: Record<string, unknown> = {}) {
+    for (const [key, value] of Object.entries(changes)) {
+      this._source[key] = value;
+      (this as Record<string, unknown>)[key] = value;
+    }
+    return changes;
+  }
+}
+
+/**
+ * Stands in for Foundry's Roll. Only `formula` is used by the tag helpers, and
+ * this returns the expression verbatim — Foundry normalizes spacing, so tests
+ * here assert the raw string where Quench asserts the normalized one.
+ */
+class Roll {
+  formula: string;
+
+  constructor(formula = "", _data: unknown = {}) {
+    this.formula = formula;
+  }
+}
+
+Object.assign(globalThis, {
+  Roll,
+  foundry: {
+    abstract: { TypeDataModel },
+    data: {
+      fields: { DataField, StringField, NumberField, BooleanField, ArrayField, ObjectField, SchemaField },
+    },
+  },
+  CONFIG: { OSE },
+  game: {
+    system: { id: "ose" },
+    i18n: {
+      localize: (key: string) => key,
+    },
+  },
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,7 @@
       "DOM.Iterable",
       "DOM.AsyncIterable"
     ],
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "strict": true,
     "outDir": "dist/module",
     "skipLibCheck": true,

--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -12,6 +12,10 @@
     "emitDeclarationOnly": true,
     "declarationMap": false,
     "noEmitOnError": false,
+    // The declaration emit needs Node-style resolution: under the base
+    // config's "bundler" the real fvtt-types field classes resolve, and tsc
+    // cannot name their types portably in the emitted .d.ts (TS2742).
+    "moduleResolution": "node",
     "rootDir": "src",
     "outDir": ".types-build"
   },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.unit.test.ts"],
+    setupFiles: ["./test/foundry-stub.ts"],
+  },
+});


### PR DESCRIPTION
### Summary

The next batch of typescript conversions and fixes. Ended up doing this as I was thinking about OSE item types, and enhancing behaviors around light sources and food items, maybe leading eventually to official GM turn tracker tools.

### Changes
* Converts item data models to ts.
  * Unit tests were written describing original `.js` class behaviors before converting to `.ts`, as a guardrail.
* Adds Vitest and the start of a non-quench test suite for logic testable against a Foundry stub.
  * CI step added to run unit tests against PRs.

Quench is fully green except for `ose.combat` failures which are pre-existing on main. Notably all `ose.item.*` tests are green.

### Not changed
* `item-sheet.js` is left as JavaScript pending an ApplicationV2 rewrite.